### PR TITLE
Report original exception when failing to load openssl

### DIFF
--- a/lib/bundler/friendly_errors.rb
+++ b/lib/bundler/friendly_errors.rb
@@ -23,7 +23,7 @@ module Bundler
         Bundler.ui.error error.message
       when LoadError
         raise error unless error.message =~ /cannot load such file -- openssl|openssl.so|libcrypto.so/
-        Bundler.ui.error "\nCould not load OpenSSL. #{error.class}: #{error}"
+        Bundler.ui.error "\nCould not load OpenSSL. #{error.class}: #{error}\n#{error.backtrace.join("\n  ")}"
         Bundler.ui.warn <<-WARN, :wrap => true
           You must recompile Ruby with OpenSSL support or change the sources in your \
           Gemfile from 'https' to 'http'. Instructions for compiling with OpenSSL \

--- a/lib/bundler/friendly_errors.rb
+++ b/lib/bundler/friendly_errors.rb
@@ -29,7 +29,6 @@ module Bundler
           Gemfile from 'https' to 'http'. Instructions for compiling with OpenSSL \
           using RVM are available at https://rvm.io/packages/openssl.
         WARN
-        Bundler.ui.trace error
       when Interrupt
         Bundler.ui.error "\nQuitting..."
         Bundler.ui.trace error

--- a/lib/bundler/friendly_errors.rb
+++ b/lib/bundler/friendly_errors.rb
@@ -23,7 +23,7 @@ module Bundler
         Bundler.ui.error error.message
       when LoadError
         raise error unless error.message =~ /cannot load such file -- openssl|openssl.so|libcrypto.so/
-        Bundler.ui.error "\nCould not load OpenSSL: #{error.class}: #{error}"
+        Bundler.ui.error "\nCould not load OpenSSL. #{error.class}: #{error}"
         Bundler.ui.warn <<-WARN, :wrap => true
           You must recompile Ruby with OpenSSL support or change the sources in your \
           Gemfile from 'https' to 'http'. Instructions for compiling with OpenSSL \

--- a/lib/bundler/friendly_errors.rb
+++ b/lib/bundler/friendly_errors.rb
@@ -23,7 +23,7 @@ module Bundler
         Bundler.ui.error error.message
       when LoadError
         raise error unless error.message =~ /cannot load such file -- openssl|openssl.so|libcrypto.so/
-        Bundler.ui.error "\nCould not load OpenSSL."
+        Bundler.ui.error "\nCould not load OpenSSL: #{error.class}: #{error}"
         Bundler.ui.warn <<-WARN, :wrap => true
           You must recompile Ruby with OpenSSL support or change the sources in your \
           Gemfile from 'https' to 'http'. Instructions for compiling with OpenSSL \

--- a/spec/bundler/friendly_errors_spec.rb
+++ b/spec/bundler/friendly_errors_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe Bundler, "friendly errors" do
       let(:error) { LoadError.new("cannot load such file -- openssl") }
 
       it "Bundler.ui receive error" do
-        expect(Bundler.ui).to receive(:error).with("\nCould not load OpenSSL.")
+        expect(Bundler.ui).to receive(:error).with("\nCould not load OpenSSL. LoadError: cannot load such file -- openssl")
         Bundler::FriendlyErrors.log_error(error)
       end
 

--- a/spec/bundler/friendly_errors_spec.rb
+++ b/spec/bundler/friendly_errors_spec.rb
@@ -115,8 +115,12 @@ RSpec.describe Bundler, "friendly errors" do
     context "LoadError" do
       let(:error) { LoadError.new("cannot load such file -- openssl") }
 
+      before do
+        allow(error).to receive(:backtrace).and_return(["backtrace"])
+      end
+
       it "Bundler.ui receive error" do
-        expect(Bundler.ui).to receive(:error).with("\nCould not load OpenSSL. LoadError: cannot load such file -- openssl")
+        expect(Bundler.ui).to receive(:error).with("\nCould not load OpenSSL. LoadError: cannot load such file -- openssl\nbacktrace")
         Bundler::FriendlyErrors.log_error(error)
       end
 

--- a/spec/bundler/friendly_errors_spec.rb
+++ b/spec/bundler/friendly_errors_spec.rb
@@ -124,11 +124,6 @@ RSpec.describe Bundler, "friendly errors" do
         expect(Bundler.ui).to receive(:warn).with(any_args, :wrap => true)
         Bundler::FriendlyErrors.log_error(error)
       end
-
-      it "Bundler.ui receive trace" do
-        expect(Bundler.ui).to receive(:trace).with(error)
-        Bundler::FriendlyErrors.log_error(error)
-      end
     end
 
     context "Interrupt" do


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

See #7192.

### What was your diagnosis of the problem?

Bundler discards `LoadError` class and message when reporting it.

### What is your fix for the problem, implemented in this PR?

Report class and message of the original exception when reporting `LoadError`.

Fixes #7192