### PR TITLE
Remove usused code and simplify concat method

### DIFF
--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -858,11 +858,7 @@ module Bundler
 
     def metadata_dependencies
       @metadata_dependencies ||= begin
-        ruby_versions = concat_ruby_version_requirements(@ruby_version)
-        if ruby_versions.empty? || !@ruby_version.exact?
-          concat_ruby_version_requirements(RubyVersion.system)
-          concat_ruby_version_requirements(locked_ruby_version_object) unless @unlock[:ruby]
-        end
+        ruby_versions = ruby_version_requirements(@ruby_version)
         [
           Dependency.new("Ruby\0", ruby_versions),
           Dependency.new("RubyGems\0", Gem::VERSION),
@@ -870,19 +866,19 @@ module Bundler
       end
     end
 
-    def concat_ruby_version_requirements(ruby_version, ruby_versions = [])
-      return ruby_versions unless ruby_version
+    def ruby_version_requirements(ruby_version)
+      return [] unless ruby_version
       if ruby_version.patchlevel
-        ruby_versions << ruby_version.to_gem_version_with_patchlevel
+        [ruby_version.to_gem_version_with_patchlevel]
       else
-        ruby_versions.concat(ruby_version.versions.map do |version|
+        ruby_version.versions.map do |version|
           requirement = Gem::Requirement.new(version)
           if requirement.exact?
             "~> #{version}.0"
           else
             requirement
           end
-        end)
+        end
       end
     end
 


### PR DESCRIPTION
The unused code is a leftover from commit 38b0e7ed64c3ca1c40f43c5aa9a1ead2f6cd7049 .
That commit disabled that RubyVersion.system is respected, but it seems that that feature wasn't missed.

### What was the end-user problem that led to this PR?

Not known.

### What was your diagnosis of the problem?

I read the bundler source code and noticed this.

### What is your fix for the problem, implemented in this PR?

My fix removes the code that seems to be of no use.

### Why did you choose this fix out of the possible options?

As a alternative I added #7559 that reactivates the code in question.
