### PR TITLE
Reactivate usused code for ruby version resolution

### DIFF
--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -860,8 +860,8 @@ module Bundler
       @metadata_dependencies ||= begin
         ruby_versions = concat_ruby_version_requirements(@ruby_version)
         if ruby_versions.empty? || !@ruby_version.exact?
-          concat_ruby_version_requirements(RubyVersion.system)
-          concat_ruby_version_requirements(locked_ruby_version_object) unless @unlock[:ruby]
+          concat_ruby_version_requirements(RubyVersion.system, ruby_versions)
+          concat_ruby_version_requirements(locked_ruby_version_object, ruby_versions) unless @unlock[:ruby]
         end
         [
           Dependency.new("Ruby\0", ruby_versions),

--- a/spec/install/gems/resolving_spec.rb
+++ b/spec/install/gems/resolving_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe "bundle install with install-time dependencies" do
 
       describe "with a < requirement" do
         let(:ruby_requirement) { %("< 5000") }
-        let(:error_message_requirement) { "< 5000" }
+        let(:error_message_requirement) { Gem::Requirement.new(["< 5000", "= #{RUBY_VERSION}.#{RUBY_PATCHLEVEL}"]).to_s }
 
         it_behaves_like "ruby version conflicts"
       end
@@ -202,7 +202,7 @@ RSpec.describe "bundle install with install-time dependencies" do
       describe "with a compound requirement" do
         let(:reqs) { ["> 0.1", "< 5000"] }
         let(:ruby_requirement) { reqs.map(&:dump).join(", ") }
-        let(:error_message_requirement) { Gem::Requirement.new(reqs).to_s }
+        let(:error_message_requirement) { Gem::Requirement.new(reqs + ["= #{RUBY_VERSION}.#{RUBY_PATCHLEVEL}"]).to_s }
 
         it_behaves_like "ruby version conflicts"
       end


### PR DESCRIPTION
The code was changed in commit 38b0e7ed64c3ca1c40f43c5aa9a1ead2f6cd7049 so that RubyVersion.system was no longer respected. This is reactivated now and specs are adjusted accordingly.

### What was the end-user problem that led to this PR?

Not known.

### What was your diagnosis of the problem?

I read the bundler source code and noticed this.

### What is your fix for the problem, implemented in this PR?

My fix re-adds the ruby version as it was before commit 38b0e7ed64c3ca1c40f43c5aa9a1ead2f6cd7049 , since it seems to be a mistake.

### Why did you choose this fix out of the possible options?

As a alternative I added #7558 that removes the code in question.
