### PR TITLE
Lock rack to 2.0.8 for tests

### DIFF
--- a/spec/support/rubygems_ext.rb
+++ b/spec/support/rubygems_ext.rb
@@ -15,7 +15,7 @@ module Spec
     }.freeze
 
     DEPS = {
-      "rack" => "~> 2.0",
+      "rack" => "2.0.8",
       "rack-test" => "~> 1.1",
       "artifice" => "~> 0.6.0",
       "compact_index" => "~> 0.11.0",


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was CI is failing due to a rack warning.

### What was your diagnosis of the problem?

My diagnosis was that our CI shouldn't break because of third party changes.

### What is your fix for the problem, implemented in this PR?

My fix is to lock the rack version our tests use.

### Why did you choose this fix out of the possible options?

I chose this fix because it gives us a more deterministic test environment, which is good.
