### PR TITLE
Make parallel tests more stable

### DIFF
--- a/spec/bundler/bundler_spec.rb
+++ b/spec/bundler/bundler_spec.rb
@@ -210,6 +210,8 @@ EOF
         gem "rack"
       G
 
+      allow(Bundler).to receive(:root).and_return(bundled_app)
+
       Bundler.mkdir_p(bundled_app.join("foo", "bar"))
       expect(bundled_app.join("foo", "bar")).to exist
     end

--- a/spec/bundler/cli_spec.rb
+++ b/spec/bundler/cli_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe "bundle executable" do
 
   context "when ENV['BUNDLE_GEMFILE'] is set to an empty string" do
     it "ignores it" do
-      gemfile bundled_app("Gemfile"), <<-G
+      gemfile bundled_app_gemfile, <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem 'rack'
       G
@@ -106,7 +106,7 @@ RSpec.describe "bundle executable" do
 
   context "when ENV['RUBYGEMS_GEMDEPS'] is set" do
     it "displays a warning" do
-      gemfile bundled_app("Gemfile"), <<-G
+      gemfile bundled_app_gemfile, <<-G
         source "#{file_uri_for(gem_repo1)}"
         gem 'rack'
       G

--- a/spec/bundler/definition_spec.rb
+++ b/spec/bundler/definition_spec.rb
@@ -210,6 +210,8 @@ RSpec.describe Bundler::Definition do
           source "#{file_uri_for(gem_repo1)}"
           gem "foo"
           G
+
+          allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
         end
 
         it "should get a locked specs list when updating all" do
@@ -267,6 +269,8 @@ RSpec.describe Bundler::Definition do
             BUNDLED WITH
                1.13.0
           L
+
+          allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
         end
 
         it "should not eagerly unlock shared dependency with bundle install conservative updating behavior" do

--- a/spec/bundler/definition_spec.rb
+++ b/spec/bundler/definition_spec.rb
@@ -213,7 +213,7 @@ RSpec.describe Bundler::Definition do
         end
 
         it "should get a locked specs list when updating all" do
-          definition = Bundler::Definition.new(bundled_app("Gemfile.lock"), [], Bundler::SourceList.new, true)
+          definition = Bundler::Definition.new(bundled_app_lock, [], Bundler::SourceList.new, true)
           locked_specs = definition.gem_version_promoter.locked_specs
           expect(locked_specs.to_a.map(&:name)).to eq ["foo"]
           expect(definition.instance_variable_get("@locked_specs").empty?).to eq true
@@ -275,7 +275,7 @@ RSpec.describe Bundler::Definition do
                                      Bundler::Dependency.new("shared_owner_b", ">= 0")]
           unlock_hash_for_bundle_install = {}
           definition = Bundler::Definition.new(
-            bundled_app("Gemfile.lock"),
+            bundled_app_lock,
             updated_deps_in_gemfile,
             source_list,
             unlock_hash_for_bundle_install
@@ -289,7 +289,7 @@ RSpec.describe Bundler::Definition do
                                      Bundler::Dependency.new("shared_owner_a", ">= 0"),
                                      Bundler::Dependency.new("shared_owner_b", ">= 0")]
           definition = Bundler::Definition.new(
-            bundled_app("Gemfile.lock"),
+            bundled_app_lock,
             updated_deps_in_gemfile,
             source_list,
             :gems => ["shared_owner_a"], :lock_shared_dependencies => true

--- a/spec/bundler/dsl_spec.rb
+++ b/spec/bundler/dsl_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Bundler::Dsl do
 
   describe "#method_missing" do
     it "raises an error for unknown DSL methods" do
-      expect(Bundler).to receive(:read_file).with(bundled_app("Gemfile").to_s).
+      expect(Bundler).to receive(:read_file).with(root.join("Gemfile").to_s).
         and_return("unknown")
 
       error_msg = "There was an error parsing `Gemfile`: Undefined local variable or method `unknown' for Gemfile. Bundler cannot continue."
@@ -83,13 +83,13 @@ RSpec.describe Bundler::Dsl do
 
   describe "#eval_gemfile" do
     it "handles syntax errors with a useful message" do
-      expect(Bundler).to receive(:read_file).with(bundled_app("Gemfile").to_s).and_return("}")
+      expect(Bundler).to receive(:read_file).with(root.join("Gemfile").to_s).and_return("}")
       expect { subject.eval_gemfile("Gemfile") }.
         to raise_error(Bundler::GemfileError, /There was an error parsing `Gemfile`: (syntax error, unexpected tSTRING_DEND|(compile error - )?syntax error, unexpected '\}'). Bundler cannot continue./)
     end
 
     it "distinguishes syntax errors from evaluation errors" do
-      expect(Bundler).to receive(:read_file).with(bundled_app("Gemfile").to_s).and_return(
+      expect(Bundler).to receive(:read_file).with(root.join("Gemfile").to_s).and_return(
         "ruby '2.1.5', :engine => 'ruby', :engine_version => '1.2.4'"
       )
       expect { subject.eval_gemfile("Gemfile") }.

--- a/spec/bundler/dsl_spec.rb
+++ b/spec/bundler/dsl_spec.rb
@@ -271,7 +271,7 @@ RSpec.describe Bundler::Dsl do
   describe "syntax errors" do
     it "will raise a Bundler::GemfileError" do
       gemfile "gem 'foo', :path => /unquoted/string/syntax/error"
-      expect { Bundler::Dsl.evaluate(bundled_app("Gemfile"), nil, true) }.
+      expect { Bundler::Dsl.evaluate(bundled_app_gemfile, nil, true) }.
         to raise_error(Bundler::GemfileError, /There was an error parsing `Gemfile`:( compile error -)? unknown regexp options - trg.+ Bundler cannot continue./)
     end
   end
@@ -279,7 +279,7 @@ RSpec.describe Bundler::Dsl do
   describe "Runtime errors" do
     it "will raise a Bundler::GemfileError" do
       gemfile "raise RuntimeError, 'foo'"
-      expect { Bundler::Dsl.evaluate(bundled_app("Gemfile"), nil, true) }.
+      expect { Bundler::Dsl.evaluate(bundled_app_gemfile, nil, true) }.
         to raise_error(Bundler::GemfileError, /There was an error parsing `Gemfile`: foo. Bundler cannot continue./i)
     end
   end

--- a/spec/bundler/env_spec.rb
+++ b/spec/bundler/env_spec.rb
@@ -177,7 +177,7 @@ RSpec.describe Bundler::Env do
           ### Gemfile.lock
 
           ```
-          <No #{bundled_app("Gemfile.lock")} found>
+          <No #{bundled_app_lock} found>
           ```
         ENV
       end

--- a/spec/bundler/gem_helper_spec.rb
+++ b/spec/bundler/gem_helper_spec.rb
@@ -178,13 +178,11 @@ RSpec.describe Bundler::GemHelper do
       end
 
       before do
-        Dir.chdir(app_path) do
-          `git init`
-          `git config user.email "you@example.com"`
-          `git config user.name "name"`
-          `git config commit.gpgsign false`
-          `git config push.default simple`
-        end
+        sys_exec("git init", :dir => app_path)
+        sys_exec("git config user.email \"you@example.com\"", :dir => app_path)
+        sys_exec("git config user.name \"name\"", :dir => app_path)
+        sys_exec("git config commit.gpgsign false", :dir => app_path)
+        sys_exec("git config push.default simple", :dir => app_path)
 
         # silence messages
         allow(Bundler.ui).to receive(:confirm)
@@ -198,13 +196,13 @@ RSpec.describe Bundler::GemHelper do
         end
 
         it "when there are uncommitted files" do
-          Dir.chdir(app_path) { `git add .` }
+          sys_exec("git add .", :dir => app_path)
           expect { Rake.application["release"].invoke }.
             to raise_error("There are files that need to be committed first.")
         end
 
         it "when there is no git remote" do
-          Dir.chdir(app_path) { `git commit -a -m "initial commit"` }
+          sys_exec("git commit -a -m \"initial commit\"", :dir => app_path)
           expect { Rake.application["release"].invoke }.to raise_error(RuntimeError)
         end
       end
@@ -213,10 +211,8 @@ RSpec.describe Bundler::GemHelper do
         let(:repo) { build_git("foo", :bare => true) }
 
         before do
-          Dir.chdir(app_path) do
-            sys_exec("git remote add origin #{file_uri_for(repo.path)}")
-            sys_exec('git commit -a -m "initial commit"')
-          end
+          sys_exec("git remote add origin #{file_uri_for(repo.path)}", :dir => app_path)
+          sys_exec('git commit -a -m "initial commit"', :dir => app_path)
         end
 
         context "on releasing" do
@@ -225,7 +221,7 @@ RSpec.describe Bundler::GemHelper do
             mock_confirm_message "Tagged v#{app_version}."
             mock_confirm_message "Pushed git commits and tags."
 
-            Dir.chdir(app_path) { sys_exec("git push -u origin master") }
+            sys_exec("git push -u origin master", :dir => app_path)
           end
 
           it "calls rubygem_push with proper arguments" do
@@ -246,9 +242,7 @@ RSpec.describe Bundler::GemHelper do
           mock_confirm_message "Tag v#{app_version} has already been created."
           expect(subject).to receive(:rubygem_push).with(app_gem_path.to_s)
 
-          Dir.chdir(app_path) do
-            `git tag -a -m \"Version #{app_version}\" v#{app_version}`
-          end
+          sys_exec("git tag -a -m \"Version #{app_version}\" v#{app_version}", :dir => app_path)
 
           Rake.application["release"].invoke
         end
@@ -269,12 +263,10 @@ RSpec.describe Bundler::GemHelper do
       end
 
       before do
-        Dir.chdir(app_path) do
-          `git init`
-          `git config user.email "you@example.com"`
-          `git config user.name "name"`
-          `git config push.default simple`
-        end
+        sys_exec("git init", :dir => app_path)
+        sys_exec("git config user.email \"you@example.com\"", :dir => app_path)
+        sys_exec("git config user.name \"name\"", :dir => app_path)
+        sys_exec("git config push.gpgsign simple", :dir => app_path)
 
         # silence messages
         allow(Bundler.ui).to receive(:confirm)

--- a/spec/bundler/plugin/index_spec.rb
+++ b/spec/bundler/plugin/index_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Bundler::Plugin::Index do
   Index = Bundler::Plugin::Index
 
   before do
+    allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
     gemfile ""
     path = lib_path(plugin_name)
     index.register_plugin("new-plugin", path.to_s, [path.join("lib").to_s], commands, sources, hooks)
@@ -117,11 +118,11 @@ RSpec.describe Bundler::Plugin::Index do
 
   describe "global index" do
     before do
-      Dir.chdir(tmp) do
-        Bundler::Plugin.reset!
-        path = lib_path("gplugin")
-        index.register_plugin("gplugin", path.to_s, [path.join("lib").to_s], [], ["glb_source"], [])
-      end
+      allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(nil)
+
+      Bundler::Plugin.reset!
+      path = lib_path("gplugin")
+      index.register_plugin("gplugin", path.to_s, [path.join("lib").to_s], [], ["glb_source"], [])
     end
 
     it "skips sources" do

--- a/spec/bundler/plugin_spec.rb
+++ b/spec/bundler/plugin_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe Bundler::Plugin do
   describe "evaluate gemfile for plugins" do
     let(:definition) { double("definition") }
     let(:builder) { double("builder") }
-    let(:gemfile) { bundled_app("Gemfile") }
+    let(:gemfile) { bundled_app_gemfile }
 
     before do
       allow(Plugin::DSL).to receive(:new) { builder }

--- a/spec/bundler/plugin_spec.rb
+++ b/spec/bundler/plugin_spec.rb
@@ -237,7 +237,7 @@ RSpec.describe Bundler::Plugin do
   describe "#root" do
     context "in app dir" do
       before do
-        gemfile ""
+        allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
       end
 
       it "returns plugin dir in app .bundle path" do
@@ -246,8 +246,11 @@ RSpec.describe Bundler::Plugin do
     end
 
     context "outside app dir" do
+      before do
+        allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(nil)
+      end
+
       it "returns plugin dir in global bundle path" do
-        Dir.chdir tmp
         expect(subject.root).to eq(home.join(".bundle/plugin"))
       end
     end

--- a/spec/bundler/settings_spec.rb
+++ b/spec/bundler/settings_spec.rb
@@ -130,6 +130,8 @@ that would suck --ehhh=oh geez it looks like i might have broken bundler somehow
 
   describe "#temporary" do
     it "reset after used" do
+      allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
+
       Bundler.settings.set_command_option :no_install, true
 
       Bundler.settings.temporary(:no_install => false) do

--- a/spec/bundler/shared_helpers_spec.rb
+++ b/spec/bundler/shared_helpers_spec.rb
@@ -4,9 +4,12 @@ RSpec.describe Bundler::SharedHelpers do
   let(:ext_lock_double) { double(:ext_lock) }
 
   before do
+    pwd_stub
     allow(Bundler.rubygems).to receive(:ext_lock).and_return(ext_lock_double)
     allow(ext_lock_double).to receive(:synchronize) {|&block| block.call }
   end
+
+  let(:pwd_stub) { allow(subject).to receive(:pwd).and_return(bundled_app) }
 
   subject { Bundler::SharedHelpers }
 
@@ -77,7 +80,7 @@ RSpec.describe Bundler::SharedHelpers do
       let(:global_rubygems_dir) { Pathname.new(bundled_app) }
 
       before do
-        Dir.mkdir ".bundle"
+        Dir.mkdir bundled_app(".bundle")
         allow(Bundler.rubygems).to receive(:user_home).and_return(global_rubygems_dir)
       end
 
@@ -91,7 +94,7 @@ RSpec.describe Bundler::SharedHelpers do
       let(:expected_bundle_dir_path) { Pathname.new("#{bundled_app}/.bundle") }
 
       before do
-        Dir.mkdir ".bundle"
+        Dir.mkdir bundled_app(".bundle")
         allow(Bundler.rubygems).to receive(:user_home).and_return(global_rubygems_dir)
       end
 
@@ -109,8 +112,8 @@ RSpec.describe Bundler::SharedHelpers do
 
     shared_examples_for "correctly determines whether to return a Gemfile path" do
       context "currently in directory with a Gemfile" do
-        before { FileUtils.touch("Gemfile") }
-        after { FileUtils.rm("Gemfile") }
+        before { FileUtils.touch(bundled_app_gemfile) }
+        after { FileUtils.rm(bundled_app_gemfile) }
 
         it "returns path of the bundle Gemfile" do
           expect(subject.in_bundle?).to eq("#{bundled_app}/Gemfile")
@@ -148,22 +151,24 @@ RSpec.describe Bundler::SharedHelpers do
   describe "#chdir" do
     let(:op_block) { proc { Dir.mkdir "nested_dir" } }
 
-    before { Dir.mkdir "chdir_test_dir" }
+    before { Dir.mkdir bundled_app("chdir_test_dir") }
 
     it "executes the passed block while in the specified directory" do
-      subject.chdir("chdir_test_dir", &op_block)
-      expect(Pathname.new("chdir_test_dir/nested_dir")).to exist
+      subject.chdir(bundled_app("chdir_test_dir"), &op_block)
+      expect(bundled_app("chdir_test_dir/nested_dir")).to exist
     end
   end
 
   describe "#pwd" do
+    let(:pwd_stub) { nil }
+
     it "returns the current absolute path" do
-      expect(subject.pwd).to eq(bundled_app)
+      expect(subject.pwd).to eq(root)
     end
   end
 
   describe "#with_clean_git_env" do
-    let(:with_clean_git_env_block) { proc { Dir.mkdir "with_clean_git_env_test_dir" } }
+    let(:with_clean_git_env_block) { proc { Dir.mkdir bundled_app("with_clean_git_env_test_dir") } }
 
     before do
       ENV["GIT_DIR"] = "ORIGINAL_ENV_GIT_DIR"
@@ -172,20 +177,20 @@ RSpec.describe Bundler::SharedHelpers do
 
     it "executes the passed block" do
       subject.with_clean_git_env(&with_clean_git_env_block)
-      expect(Pathname.new("with_clean_git_env_test_dir")).to exist
+      expect(bundled_app("with_clean_git_env_test_dir")).to exist
     end
 
     context "when a block is passed" do
       let(:with_clean_git_env_block) do
         proc do
-          Dir.mkdir "git_dir_test_dir" unless ENV["GIT_DIR"].nil?
-          Dir.mkdir "git_work_tree_test_dir" unless ENV["GIT_WORK_TREE"].nil?
+          Dir.mkdir bundled_app("git_dir_test_dir") unless ENV["GIT_DIR"].nil?
+          Dir.mkdir bundled_app("git_work_tree_test_dir") unless ENV["GIT_WORK_TREE"].nil?
         end end
 
       it "uses a fresh git env for execution" do
         subject.with_clean_git_env(&with_clean_git_env_block)
-        expect(Pathname.new("git_dir_test_dir")).to_not exist
-        expect(Pathname.new("git_work_tree_test_dir")).to_not exist
+        expect(bundled_app("git_dir_test_dir")).to_not exist
+        expect(bundled_app("git_work_tree_test_dir")).to_not exist
       end
     end
 
@@ -225,7 +230,7 @@ RSpec.describe Bundler::SharedHelpers do
     end
 
     shared_examples_for "ENV['PATH'] gets set correctly" do
-      before { Dir.mkdir ".bundle" }
+      before { Dir.mkdir bundled_app(".bundle") }
 
       it "ensures bundle bin path is in ENV['PATH']" do
         subject.set_bundle_environment
@@ -245,7 +250,7 @@ RSpec.describe Bundler::SharedHelpers do
       let(:ruby_lib_path) { "stubbed_ruby_lib_dir" }
 
       before do
-        allow(Bundler::SharedHelpers).to receive(:bundler_ruby_lib).and_return(ruby_lib_path)
+        allow(subject).to receive(:bundler_ruby_lib).and_return(ruby_lib_path)
       end
 
       it "ensures bundler's ruby version lib path is in ENV['RUBYLIB']" do
@@ -264,7 +269,7 @@ RSpec.describe Bundler::SharedHelpers do
     end
 
     it "ignores if bundler_ruby_lib is same as rubylibdir" do
-      allow(Bundler::SharedHelpers).to receive(:bundler_ruby_lib).and_return(RbConfig::CONFIG["rubylibdir"])
+      allow(subject).to receive(:bundler_ruby_lib).and_return(RbConfig::CONFIG["rubylibdir"])
 
       subject.set_bundle_environment
 

--- a/spec/cache/gems_spec.rb
+++ b/spec/cache/gems_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe "bundle cache" do
 
       bundle "cache"
 
-      expect(bundled_app("Gemfile.lock")).to exist
+      expect(bundled_app_lock).to exist
     end
   end
 
@@ -165,11 +165,11 @@ RSpec.describe "bundle cache" do
     end
 
     it "should not explode if the lockfile is not present" do
-      FileUtils.rm(bundled_app("Gemfile.lock"))
+      FileUtils.rm(bundled_app_lock)
 
       bundle :cache
 
-      expect(bundled_app("Gemfile.lock")).to exist
+      expect(bundled_app_lock).to exist
     end
   end
 

--- a/spec/cache/git_spec.rb
+++ b/spec/cache/git_spec.rb
@@ -155,10 +155,8 @@ RSpec.describe "bundle cache with git" do
       s.add_dependency "submodule"
     end
 
-    Dir.chdir(lib_path("has_submodule-1.0")) do
-      sys_exec "git submodule add #{lib_path("submodule-1.0")} submodule-1.0"
-      `git commit -m "submodulator"`
-    end
+    sys_exec "git submodule add #{lib_path("submodule-1.0")} submodule-1.0", :dir => lib_path("has_submodule-1.0")
+    sys_exec "git commit -m \"submodulator\"", :dir => lib_path("has_submodule-1.0")
 
     install_gemfile <<-G
       git "#{lib_path("has_submodule-1.0")}", :submodules => true do

--- a/spec/commands/add_spec.rb
+++ b/spec/commands/add_spec.rb
@@ -30,25 +30,25 @@ RSpec.describe "bundle add" do
   describe "without version specified" do
     it "version requirement becomes ~> major.minor.patch when resolved version is < 1.0" do
       bundle "add 'bar'"
-      expect(bundled_app("Gemfile").read).to match(/gem "bar", "~> 0.12.3"/)
+      expect(bundled_app_gemfile.read).to match(/gem "bar", "~> 0.12.3"/)
       expect(the_bundle).to include_gems "bar 0.12.3"
     end
 
     it "version requirement becomes ~> major.minor when resolved version is > 1.0" do
       bundle "add 'baz'"
-      expect(bundled_app("Gemfile").read).to match(/gem "baz", "~> 1.2"/)
+      expect(bundled_app_gemfile.read).to match(/gem "baz", "~> 1.2"/)
       expect(the_bundle).to include_gems "baz 1.2.3"
     end
 
     it "version requirement becomes ~> major.minor.patch.pre when resolved version is < 1.0" do
       bundle "add 'cat'"
-      expect(bundled_app("Gemfile").read).to match(/gem "cat", "~> 0.12.3.pre"/)
+      expect(bundled_app_gemfile.read).to match(/gem "cat", "~> 0.12.3.pre"/)
       expect(the_bundle).to include_gems "cat 0.12.3.pre"
     end
 
     it "version requirement becomes ~> major.minor.pre when resolved version is > 1.0.pre" do
       bundle "add 'dog'"
-      expect(bundled_app("Gemfile").read).to match(/gem "dog", "~> 1.1.pre"/)
+      expect(bundled_app_gemfile.read).to match(/gem "dog", "~> 1.1.pre"/)
       expect(the_bundle).to include_gems "dog 1.1.3.pre"
     end
   end
@@ -56,14 +56,14 @@ RSpec.describe "bundle add" do
   describe "with --version" do
     it "adds dependency of specified version and runs install" do
       bundle "add 'foo' --version='~> 1.0'"
-      expect(bundled_app("Gemfile").read).to match(/gem "foo", "~> 1.0"/)
+      expect(bundled_app_gemfile.read).to match(/gem "foo", "~> 1.0"/)
       expect(the_bundle).to include_gems "foo 1.1"
     end
 
     it "adds multiple version constraints when specified" do
       requirements = ["< 3.0", "> 1.0"]
       bundle "add 'foo' --version='#{requirements.join(", ")}'"
-      expect(bundled_app("Gemfile").read).to match(/gem "foo", #{Gem::Requirement.new(requirements).as_list.map(&:dump).join(', ')}/)
+      expect(bundled_app_gemfile.read).to match(/gem "foo", #{Gem::Requirement.new(requirements).as_list.map(&:dump).join(', ')}/)
       expect(the_bundle).to include_gems "foo 2.0"
     end
   end
@@ -71,13 +71,13 @@ RSpec.describe "bundle add" do
   describe "with --group" do
     it "adds dependency for the specified group" do
       bundle "add 'foo' --group='development'"
-      expect(bundled_app("Gemfile").read).to match(/gem "foo", "~> 2.0", :group => :development/)
+      expect(bundled_app_gemfile.read).to match(/gem "foo", "~> 2.0", :group => :development/)
       expect(the_bundle).to include_gems "foo 2.0"
     end
 
     it "adds dependency to more than one group" do
       bundle "add 'foo' --group='development, test'"
-      expect(bundled_app("Gemfile").read).to match(/gem "foo", "~> 2.0", :groups => \[:development, :test\]/)
+      expect(bundled_app_gemfile.read).to match(/gem "foo", "~> 2.0", :groups => \[:development, :test\]/)
       expect(the_bundle).to include_gems "foo 2.0"
     end
   end
@@ -86,7 +86,7 @@ RSpec.describe "bundle add" do
     it "adds dependency with specified source" do
       bundle "add 'foo' --source='#{file_uri_for(gem_repo2)}'"
 
-      expect(bundled_app("Gemfile").read).to match(/gem "foo", "~> 2.0", :source => "#{file_uri_for(gem_repo2)}"/)
+      expect(bundled_app_gemfile.read).to match(/gem "foo", "~> 2.0", :source => "#{file_uri_for(gem_repo2)}"/)
       expect(the_bundle).to include_gems "foo 2.0"
     end
   end
@@ -95,7 +95,7 @@ RSpec.describe "bundle add" do
     it "adds dependency with specified github source" do
       bundle "add foo --git=#{lib_path("foo-2.0")}"
 
-      expect(bundled_app("Gemfile").read).to match(/gem "foo", "~> 2.0", :git => "#{lib_path("foo-2.0")}"/)
+      expect(bundled_app_gemfile.read).to match(/gem "foo", "~> 2.0", :git => "#{lib_path("foo-2.0")}"/)
       expect(the_bundle).to include_gems "foo 2.0"
     end
   end
@@ -108,7 +108,7 @@ RSpec.describe "bundle add" do
     it "adds dependency with specified github source and branch" do
       bundle "add foo --git=#{lib_path("foo-2.0")} --branch=test"
 
-      expect(bundled_app("Gemfile").read).to match(/gem "foo", "~> 2.0", :git => "#{lib_path("foo-2.0")}", :branch => "test"/)
+      expect(bundled_app_gemfile.read).to match(/gem "foo", "~> 2.0", :git => "#{lib_path("foo-2.0")}", :branch => "test"/)
       expect(the_bundle).to include_gems "foo 2.0"
     end
   end
@@ -117,14 +117,14 @@ RSpec.describe "bundle add" do
     it "adds gem to Gemfile but is not installed" do
       bundle "add foo --skip-install --version=2.0"
 
-      expect(bundled_app("Gemfile").read).to match(/gem "foo", "= 2.0"/)
+      expect(bundled_app_gemfile.read).to match(/gem "foo", "= 2.0"/)
       expect(the_bundle).to_not include_gems "foo 2.0"
     end
   end
 
   it "using combination of short form options works like long form" do
     bundle "add 'foo' -s='#{file_uri_for(gem_repo2)}' -g='development' -v='~>1.0'"
-    expect(bundled_app("Gemfile").read).to include %(gem "foo", "~> 1.0", :group => :development, :source => "#{file_uri_for(gem_repo2)}")
+    expect(bundled_app_gemfile.read).to include %(gem "foo", "~> 1.0", :group => :development, :source => "#{file_uri_for(gem_repo2)}")
     expect(the_bundle).to include_gems "foo 1.1"
   end
 
@@ -153,7 +153,7 @@ RSpec.describe "bundle add" do
   describe "with --optimistic" do
     it "adds optimistic version" do
       bundle! "add 'foo' --optimistic"
-      expect(bundled_app("Gemfile").read).to include %(gem "foo", ">= 2.0")
+      expect(bundled_app_gemfile.read).to include %(gem "foo", ">= 2.0")
       expect(the_bundle).to include_gems "foo 2.0"
     end
   end
@@ -161,7 +161,7 @@ RSpec.describe "bundle add" do
   describe "with --strict option" do
     it "adds strict version" do
       bundle! "add 'foo' --strict"
-      expect(bundled_app("Gemfile").read).to include %(gem "foo", "= 2.0")
+      expect(bundled_app_gemfile.read).to include %(gem "foo", "= 2.0")
       expect(the_bundle).to include_gems "foo 2.0"
     end
   end
@@ -169,7 +169,7 @@ RSpec.describe "bundle add" do
   describe "with no option" do
     it "adds pessimistic version" do
       bundle! "add 'foo'"
-      expect(bundled_app("Gemfile").read).to include %(gem "foo", "~> 2.0")
+      expect(bundled_app_gemfile.read).to include %(gem "foo", "~> 2.0")
       expect(the_bundle).to include_gems "foo 2.0"
     end
   end
@@ -186,8 +186,8 @@ RSpec.describe "bundle add" do
     it "adds multiple gems to gemfile" do
       bundle! "add bar baz"
 
-      expect(bundled_app("Gemfile").read).to match(/gem "bar", "~> 0.12.3"/)
-      expect(bundled_app("Gemfile").read).to match(/gem "baz", "~> 1.2"/)
+      expect(bundled_app_gemfile.read).to match(/gem "bar", "~> 0.12.3"/)
+      expect(bundled_app_gemfile.read).to match(/gem "baz", "~> 1.2"/)
     end
 
     it "throws error if any of the specified gems are present in the gemfile with different version" do

--- a/spec/commands/binstubs_spec.rb
+++ b/spec/commands/binstubs_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe "bundle binstubs <gem>" do
 
       context "when BUNDLER_VERSION is set" do
         it "runs the correct version of bundler" do
-          sys_exec "#{bundled_app("bin/bundle")} install", "BUNDLER_VERSION" => "999.999.999"
+          sys_exec "#{bundled_app("bin/bundle")} install", :env => { "BUNDLER_VERSION" => "999.999.999" }
           expect(exitstatus).to eq(42) if exitstatus
           expect(err).to include("Activating bundler (~> 999.999) failed:").
             and include("To install the version of bundler this project requires, run `gem install bundler -v '~> 999.999'`")

--- a/spec/commands/binstubs_spec.rb
+++ b/spec/commands/binstubs_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe "bundle binstubs <gem>" do
 
         bundle "binstubs rack"
 
-        File.open("bin/bundle", "wb") do |file|
+        File.open(bundled_app("bin/bundle"), "wb") do |file|
           file.print "OMG"
         end
 
@@ -301,7 +301,7 @@ RSpec.describe "bundle binstubs <gem>" do
 
         bundle "binstubs rack --shebang jruby"
 
-        expect(File.open("bin/rackup").gets).to eq("#!/usr/bin/env jruby\n")
+        expect(File.open(bundled_app("bin/rackup")).gets).to eq("#!/usr/bin/env jruby\n")
       end
     end
   end

--- a/spec/commands/binstubs_spec.rb
+++ b/spec/commands/binstubs_spec.rb
@@ -221,7 +221,7 @@ RSpec.describe "bundle binstubs <gem>" do
 
       context "without a lockfile" do
         it "falls back to the latest installed bundler" do
-          FileUtils.rm bundled_app("Gemfile.lock")
+          FileUtils.rm bundled_app_lock
           sys_exec! bundled_app("bin/bundle").to_s
           expect(out).to eq "system bundler #{system_bundler_version}\n[]"
         end

--- a/spec/commands/check_spec.rb
+++ b/spec/commands/check_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "bundle check" do
 
     bundle "check"
 
-    expect(bundled_app("Gemfile.lock")).to exist
+    expect(bundled_app_lock).to exist
   end
 
   it "does not create a Gemfile.lock if --dry-run was passed" do
@@ -46,7 +46,7 @@ RSpec.describe "bundle check" do
 
     bundle "check --dry-run"
 
-    expect(bundled_app("Gemfile.lock")).not_to exist
+    expect(bundled_app_lock).not_to exist
   end
 
   it "prints a generic error if the missing gems are unresolvable" do
@@ -232,7 +232,7 @@ RSpec.describe "bundle check" do
     G
 
     bundle! "install", forgotten_command_line_options(:deployment => true)
-    FileUtils.rm(bundled_app("Gemfile.lock"))
+    FileUtils.rm(bundled_app_lock)
 
     bundle :check
     expect(last_command).to be_failure

--- a/spec/commands/check_spec.rb
+++ b/spec/commands/check_spec.rb
@@ -18,8 +18,7 @@ RSpec.describe "bundle check" do
       gem "rails"
     G
 
-    Dir.chdir tmp
-    bundle "check --gemfile bundled_app/Gemfile"
+    bundle "check --gemfile bundled_app/Gemfile", :dir => tmp
     expect(out).to include("The Gemfile's dependencies are satisfied")
   end
 
@@ -29,7 +28,7 @@ RSpec.describe "bundle check" do
       gem "rails"
     G
 
-    FileUtils.rm("Gemfile.lock")
+    FileUtils.rm(bundled_app_lock)
 
     bundle "check"
 
@@ -42,7 +41,7 @@ RSpec.describe "bundle check" do
       gem "rails"
     G
 
-    FileUtils.rm("Gemfile.lock")
+    FileUtils.rm(bundled_app_lock)
 
     bundle "check --dry-run"
 

--- a/spec/commands/clean_spec.rb
+++ b/spec/commands/clean_spec.rb
@@ -585,11 +585,11 @@ RSpec.describe "bundle clean" do
     bundle "install"
 
     # mimic 7 length git revisions in Gemfile.lock
-    gemfile_lock = File.read(bundled_app("Gemfile.lock")).split("\n")
+    gemfile_lock = File.read(bundled_app_lock).split("\n")
     gemfile_lock.each_with_index do |line, index|
       gemfile_lock[index] = line[0..(11 + 7)] if line.include?("  revision:")
     end
-    lockfile(bundled_app("Gemfile.lock"), gemfile_lock.join("\n"))
+    lockfile(bundled_app_lock, gemfile_lock.join("\n"))
 
     bundle "config set path vendor/bundle"
     bundle "install"

--- a/spec/commands/config_spec.rb
+++ b/spec/commands/config_spec.rb
@@ -54,14 +54,13 @@ RSpec.describe ".bundle/config" do
 
     it "can provide a relative path with the environment variable" do
       FileUtils.mkdir_p bundled_app("omg")
-      Dir.chdir bundled_app("omg")
 
       ENV["BUNDLE_APP_CONFIG"] = "../foo"
-      bundle "install", forgotten_command_line_options(:path => "vendor/bundle")
+      bundle "install", forgotten_command_line_options(:path => "vendor/bundle").merge(:dir => bundled_app("omg"))
 
       expect(bundled_app(".bundle")).not_to exist
       expect(bundled_app("../foo/config")).to exist
-      expect(the_bundle).to include_gems "rack 1.0.0"
+      expect(the_bundle).to include_gems "rack 1.0.0", :dir => bundled_app("omg")
     end
   end
 
@@ -138,7 +137,7 @@ RSpec.describe ".bundle/config" do
     it "expands the path at time of setting" do
       bundle "config set --global local.foo .."
       run "puts Bundler.settings['local.foo']"
-      expect(out).to eq(File.expand_path(Dir.pwd + "/.."))
+      expect(out).to eq(File.expand_path(bundled_app.to_s + "/.."))
     end
 
     it "saves with parseable option" do
@@ -205,7 +204,7 @@ RSpec.describe ".bundle/config" do
     it "expands the path at time of setting" do
       bundle "config set --local local.foo .."
       run "puts Bundler.settings['local.foo']"
-      expect(out).to eq(File.expand_path(Dir.pwd + "/.."))
+      expect(out).to eq(File.expand_path(bundled_app.to_s + "/.."))
     end
 
     it "can be deleted with parseable option" do
@@ -484,7 +483,7 @@ RSpec.describe "setting gemfile via config" do
       G
 
       bundle "config set --local gemfile #{bundled_app("NotGemfile")}"
-      expect(File.exist?(".bundle/config")).to eq(true)
+      expect(File.exist?(bundled_app(".bundle/config"))).to eq(true)
 
       bundle "config list"
       expect(out).to include("NotGemfile")

--- a/spec/commands/doctor_spec.rb
+++ b/spec/commands/doctor_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe "bundle doctor" do
     before(:each) do
       stat = double("stat")
       unwritable_file = double("file")
+      allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
       allow(Find).to receive(:find).with(Bundler.bundle_path.to_s) { [unwritable_file] }
       allow(File).to receive(:stat).with(unwritable_file) { stat }
       allow(stat).to receive(:uid) { Process.uid }
@@ -72,6 +73,7 @@ RSpec.describe "bundle doctor" do
     before(:each) do
       @stat = double("stat")
       @unwritable_file = double("file")
+      allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
       allow(Find).to receive(:find).with(Bundler.bundle_path.to_s) { [@unwritable_file] }
       allow(File).to receive(:stat).with(@unwritable_file) { @stat }
     end

--- a/spec/commands/info_spec.rb
+++ b/spec/commands/info_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "bundle info" do
 
       bundle! "info rails"
 
-      expect(bundled_app("Gemfile.lock")).to exist
+      expect(bundled_app_lock).to exist
     end
 
     it "prints information if gem exists in bundle" do

--- a/spec/commands/info_spec.rb
+++ b/spec/commands/info_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "bundle info" do
     end
 
     it "creates a Gemfile.lock when invoked with a gem name" do
-      FileUtils.rm("Gemfile.lock")
+      FileUtils.rm(bundled_app_lock)
 
       bundle! "info rails"
 

--- a/spec/commands/init_spec.rb
+++ b/spec/commands/init_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "bundle init" do
   it "generates a Gemfile" do
     bundle! :init
     expect(out).to include("Writing new Gemfile")
-    expect(bundled_app("Gemfile")).to be_file
+    expect(bundled_app_gemfile).to be_file
   end
 
   context "when a Gemfile already exists" do
@@ -15,7 +15,7 @@ RSpec.describe "bundle init" do
     end
 
     it "does not change existing Gemfiles" do
-      expect { bundle :init }.not_to change { File.read(bundled_app("Gemfile")) }
+      expect { bundle :init }.not_to change { File.read(bundled_app_gemfile) }
     end
 
     it "notifies the user that an existing Gemfile already exists" do
@@ -75,7 +75,7 @@ RSpec.describe "bundle init" do
 
       bundle :init, :gemspec => spec_file
 
-      gemfile = bundled_app("Gemfile").read
+      gemfile = bundled_app_gemfile.read
       expect(gemfile).to match(%r{source 'https://rubygems.org'})
       expect(gemfile.scan(/gem "rack", "= 1.0.1"/).size).to eq(1)
       expect(gemfile.scan(/gem "rspec", "= 1.2"/).size).to eq(1)

--- a/spec/commands/init_spec.rb
+++ b/spec/commands/init_spec.rb
@@ -32,9 +32,7 @@ RSpec.describe "bundle init" do
 
       FileUtils.mkdir bundled_app(subdir)
 
-      Dir.chdir bundled_app(subdir) do
-        bundle! :init
-      end
+      bundle! :init, :dir => bundled_app(subdir)
 
       expect(out).to include("Writing new Gemfile")
       expect(bundled_app("#{subdir}/Gemfile")).to be_file
@@ -50,9 +48,7 @@ RSpec.describe "bundle init" do
       mode = File.stat(bundled_app(subdir)).mode ^ 0o222
       FileUtils.chmod mode, bundled_app(subdir)
 
-      Dir.chdir bundled_app(subdir) do
-        bundle :init
-      end
+      bundle :init, :dir => bundled_app(subdir)
 
       expect(err).to include("directory is not writable")
       expect(Dir[bundled_app("#{subdir}/*")]).to be_empty
@@ -133,9 +129,7 @@ RSpec.describe "bundle init" do
 
         FileUtils.mkdir bundled_app(subdir)
 
-        Dir.chdir bundled_app(subdir) do
-          bundle! :init
-        end
+        bundle! :init, :dir => bundled_app(subdir)
 
         expect(out).to include("Writing new gems.rb")
         expect(bundled_app("#{subdir}/gems.rb")).to be_file

--- a/spec/commands/inject_spec.rb
+++ b/spec/commands/inject_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe "bundle inject", :bundler => "< 3" do
 
   context "without a lockfile" do
     it "locks with the injected gems" do
-      expect(bundled_app("Gemfile.lock")).not_to exist
+      expect(bundled_app_lock).not_to exist
       bundle "inject 'rack-obama' '> 0'"
-      expect(bundled_app("Gemfile.lock").read).to match(/rack-obama/)
+      expect(bundled_app_lock.read).to match(/rack-obama/)
     end
   end
 
@@ -28,9 +28,9 @@ RSpec.describe "bundle inject", :bundler => "< 3" do
     end
 
     it "locks with the injected gems" do
-      expect(bundled_app("Gemfile.lock").read).not_to match(/rack-obama/)
+      expect(bundled_app_lock.read).not_to match(/rack-obama/)
       bundle "inject 'rack-obama' '> 0'"
-      expect(bundled_app("Gemfile.lock").read).to match(/rack-obama/)
+      expect(bundled_app_lock.read).to match(/rack-obama/)
     end
   end
 
@@ -92,9 +92,9 @@ Usage: "bundle inject GEM VERSION"
     end
 
     it "locks with the injected gems" do
-      expect(bundled_app("Gemfile.lock").read).not_to match(/rack-obama/)
+      expect(bundled_app_lock.read).not_to match(/rack-obama/)
       bundle "inject 'rack-obama' '> 0'"
-      expect(bundled_app("Gemfile.lock").read).to match(/rack-obama/)
+      expect(bundled_app_lock.read).to match(/rack-obama/)
     end
 
     it "restores frozen afterwards" do
@@ -111,7 +111,7 @@ Usage: "bundle inject GEM VERSION"
       bundle "inject 'rack' '> 0'"
       expect(err).to match(/trying to install in deployment mode after changing/)
 
-      expect(bundled_app("Gemfile.lock").read).not_to match(/rack-obama/)
+      expect(bundled_app_lock.read).not_to match(/rack-obama/)
     end
   end
 end

--- a/spec/commands/inject_spec.rb
+++ b/spec/commands/inject_spec.rb
@@ -22,9 +22,9 @@ RSpec.describe "bundle inject", :bundler => "< 3" do
     end
 
     it "adds the injected gems to the Gemfile" do
-      expect(bundled_app("Gemfile").read).not_to match(/rack-obama/)
+      expect(bundled_app_gemfile.read).not_to match(/rack-obama/)
       bundle "inject 'rack-obama' '> 0'"
-      expect(bundled_app("Gemfile").read).to match(/rack-obama/)
+      expect(bundled_app_gemfile.read).to match(/rack-obama/)
     end
 
     it "locks with the injected gems" do
@@ -54,7 +54,7 @@ Usage: "bundle inject GEM VERSION"
   context "with source option" do
     it "add gem with source option in gemfile" do
       bundle "inject 'foo' '>0' --source #{file_uri_for(gem_repo1)}"
-      gemfile = bundled_app("Gemfile").read
+      gemfile = bundled_app_gemfile.read
       str = "gem \"foo\", \"> 0\", :source => \"#{file_uri_for(gem_repo1)}\""
       expect(gemfile).to include str
     end
@@ -63,14 +63,14 @@ Usage: "bundle inject GEM VERSION"
   context "with group option" do
     it "add gem with group option in gemfile" do
       bundle "inject 'rack-obama' '>0' --group=development"
-      gemfile = bundled_app("Gemfile").read
+      gemfile = bundled_app_gemfile.read
       str = "gem \"rack-obama\", \"> 0\", :group => :development"
       expect(gemfile).to include str
     end
 
     it "add gem with multiple groups in gemfile" do
       bundle "inject 'rack-obama' '>0' --group=development,test"
-      gemfile = bundled_app("Gemfile").read
+      gemfile = bundled_app_gemfile.read
       str = "gem \"rack-obama\", \"> 0\", :groups => [:development, :test]"
       expect(gemfile).to include str
     end
@@ -88,7 +88,7 @@ Usage: "bundle inject GEM VERSION"
 
     it "injects anyway" do
       bundle "inject 'rack-obama' '> 0'"
-      expect(bundled_app("Gemfile").read).to match(/rack-obama/)
+      expect(bundled_app_gemfile.read).to match(/rack-obama/)
     end
 
     it "locks with the injected gems" do

--- a/spec/commands/install_spec.rb
+++ b/spec/commands/install_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "bundle install with gem sources" do
       G
 
       expect(err).to include('StandardError, "FAIL"')
-      expect(bundled_app("Gemfile.lock")).not_to exist
+      expect(bundled_app_lock).not_to exist
     end
 
     it "creates a Gemfile.lock" do
@@ -26,7 +26,7 @@ RSpec.describe "bundle install with gem sources" do
         gem "rack"
       G
 
-      expect(bundled_app("Gemfile.lock")).to exist
+      expect(bundled_app_lock).to exist
     end
 
     it "does not create ./.bundle by default", :bundler => "< 3" do
@@ -66,13 +66,13 @@ RSpec.describe "bundle install with gem sources" do
         gem 'rack'
       G
 
-      lockfile = File.read(bundled_app("Gemfile.lock"))
+      lockfile = File.read(bundled_app_lock)
 
       install_gemfile <<-G
         raise StandardError, "FAIL"
       G
 
-      expect(File.read(bundled_app("Gemfile.lock"))).to eq(lockfile)
+      expect(File.read(bundled_app_lock)).to eq(lockfile)
     end
 
     it "does not touch the lockfile if nothing changed" do
@@ -81,7 +81,7 @@ RSpec.describe "bundle install with gem sources" do
         gem "rack"
       G
 
-      expect { run "1" }.not_to change { File.mtime(bundled_app("Gemfile.lock")) }
+      expect { run "1" }.not_to change { File.mtime(bundled_app_lock) }
     end
 
     it "fetches gems" do
@@ -320,7 +320,7 @@ RSpec.describe "bundle install with gem sources" do
       install_gemfile <<-G
       G
 
-      expect(File.exist?(bundled_app("Gemfile.lock"))).to eq(true)
+      expect(File.exist?(bundled_app_lock)).to eq(true)
     end
 
     context "throws a warning if a gem is added twice in Gemfile" do

--- a/spec/commands/install_spec.rb
+++ b/spec/commands/install_spec.rb
@@ -504,23 +504,20 @@ RSpec.describe "bundle install with gem sources" do
   end
 
   describe "when Bundler root contains regex chars" do
-    before do
+    it "doesn't blow up" do
       root_dir = tmp("foo[]bar")
 
       FileUtils.mkdir_p(root_dir)
-      Dir.chdir(root_dir)
-    end
 
-    it "doesn't blow up" do
       build_lib "foo"
       gemfile = <<-G
         gem 'foo', :path => "#{lib_path("foo-1.0")}"
       G
-      File.open("Gemfile", "w") do |file|
+      File.open("#{root_dir}/Gemfile", "w") do |file|
         file.puts gemfile
       end
 
-      bundle :install
+      bundle :install, :dir => root_dir
 
       expect(exitstatus).to eq(0) if exitstatus
     end

--- a/spec/commands/lock_spec.rb
+++ b/spec/commands/lock_spec.rb
@@ -195,6 +195,8 @@ RSpec.describe "bundle lock" do
         gem 'foo'
         gem 'qux'
       G
+
+      allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
     end
 
     it "single gem updates dependent gem to minor" do
@@ -213,12 +215,15 @@ RSpec.describe "bundle lock" do
   it "supports adding new platforms" do
     bundle! "lock --add-platform java x86-mingw32"
 
+    allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
     lockfile = Bundler::LockfileParser.new(read_lockfile)
     expect(lockfile.platforms).to match_array(local_platforms.unshift(java, mingw).uniq)
   end
 
   it "supports adding the `ruby` platform" do
     bundle! "lock --add-platform ruby"
+
+    allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
     lockfile = Bundler::LockfileParser.new(read_lockfile)
     expect(lockfile.platforms).to match_array(local_platforms.unshift("ruby").uniq)
   end
@@ -231,6 +236,7 @@ RSpec.describe "bundle lock" do
   it "allows removing platforms" do
     bundle! "lock --add-platform java x86-mingw32"
 
+    allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
     lockfile = Bundler::LockfileParser.new(read_lockfile)
     expect(lockfile.platforms).to match_array(local_platforms.unshift(java, mingw).uniq)
 

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -232,7 +232,7 @@ RSpec.describe "bundle gem" do
       load_paths = [lib_dir, spec_dir]
       load_path_str = "-I#{load_paths.join(File::PATH_SEPARATOR)}"
 
-      sys_exec! "#{Gem.ruby} #{load_path_str} #{bindir.join("bundle")} gem #{gem_name}", "PATH" => ""
+      sys_exec! "#{Gem.ruby} #{load_path_str} #{bindir.join("bundle")} gem #{gem_name}", :env => { "PATH" => "" }
     end
 
     it "creates the gem without the need for git" do

--- a/spec/commands/pristine_spec.rb
+++ b/spec/commands/pristine_spec.rb
@@ -28,6 +28,8 @@ RSpec.describe "bundle pristine", :ruby_repo do
 
       gemspec
     G
+
+    allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
   end
 
   context "when sourced from RubyGems" do

--- a/spec/commands/remove_spec.rb
+++ b/spec/commands/remove_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe "bundle remove" do
 
         bundle "remove rack"
 
-        expect(err).to include("`rack` is not specified in #{bundled_app("Gemfile")} so it could not be removed.")
+        expect(err).to include("`rack` is not specified in #{bundled_app_gemfile} so it could not be removed.")
       end
     end
   end
@@ -91,7 +91,7 @@ RSpec.describe "bundle remove" do
 
         bundle "remove rails rack minitest"
 
-        expect(err).to include("`rack` is not specified in #{bundled_app("Gemfile")} so it could not be removed.")
+        expect(err).to include("`rack` is not specified in #{bundled_app_gemfile} so it could not be removed.")
         gemfile_should_be <<-G
           source "#{file_uri_for(gem_repo1)}"
 
@@ -436,7 +436,7 @@ RSpec.describe "bundle remove" do
 
         bundle "remove rack"
 
-        expect(err).to include("`rack` is not specified in #{bundled_app("Gemfile")} so it could not be removed.")
+        expect(err).to include("`rack` is not specified in #{bundled_app_gemfile} so it could not be removed.")
       end
     end
 

--- a/spec/commands/show_spec.rb
+++ b/spec/commands/show_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "bundle show", :bundler => "< 3" do
     end
 
     it "creates a Gemfile.lock if one did not exist" do
-      FileUtils.rm("Gemfile.lock")
+      FileUtils.rm(bundled_app_lock)
 
       bundle! "show"
 
@@ -18,7 +18,7 @@ RSpec.describe "bundle show", :bundler => "< 3" do
     end
 
     it "creates a Gemfile.lock when invoked with a gem name" do
-      FileUtils.rm("Gemfile.lock")
+      FileUtils.rm(bundled_app_lock)
 
       bundle! "show rails"
 
@@ -143,13 +143,12 @@ RSpec.describe "bundle show", :bundler => "< 3" do
   context "in a fresh gem in a blank git repo" do
     before :each do
       build_git "foo", :path => lib_path("foo")
-      Dir.chdir lib_path("foo")
-      File.open("Gemfile", "w") {|f| f.puts "gemspec" }
-      sys_exec "rm -rf .git && git init"
+      File.open(lib_path("foo/Gemfile"), "w") {|f| f.puts "gemspec" }
+      sys_exec "rm -rf .git && git init", :dir => lib_path("foo")
     end
 
     it "does not output git errors" do
-      bundle :show
+      bundle :show, :dir => lib_path("foo")
       expect(err_without_deprecations).to be_empty
     end
   end

--- a/spec/commands/show_spec.rb
+++ b/spec/commands/show_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "bundle show", :bundler => "< 3" do
 
       bundle! "show"
 
-      expect(bundled_app("Gemfile.lock")).to exist
+      expect(bundled_app_lock).to exist
     end
 
     it "creates a Gemfile.lock when invoked with a gem name" do
@@ -22,7 +22,7 @@ RSpec.describe "bundle show", :bundler => "< 3" do
 
       bundle! "show rails"
 
-      expect(bundled_app("Gemfile.lock")).to exist
+      expect(bundled_app_lock).to exist
     end
 
     it "prints path if gem exists in bundle" do

--- a/spec/commands/update_spec.rb
+++ b/spec/commands/update_spec.rb
@@ -831,6 +831,7 @@ RSpec.describe "bundle update --bundler" do
       source "#{file_uri_for(gem_repo4)}"
       gem "rack"
     G
+    allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
     lockfile lockfile.sub(/(^\s*)#{Bundler::VERSION}($)/, '\11.0.0\2')
 
     FileUtils.rm_r gem_repo4

--- a/spec/commands/update_spec.rb
+++ b/spec/commands/update_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "bundle update" do
         exit!
       G
       bundle "update"
-      expect(bundled_app("Gemfile.lock")).to exist
+      expect(bundled_app_lock).to exist
     end
   end
 
@@ -54,7 +54,7 @@ RSpec.describe "bundle update" do
         exit!
       G
       bundle "update", :all => true
-      expect(bundled_app("Gemfile.lock")).to exist
+      expect(bundled_app_lock).to exist
     end
   end
 

--- a/spec/install/deploy_spec.rb
+++ b/spec/install/deploy_spec.rb
@@ -43,13 +43,12 @@ RSpec.describe "install with --deployment or --frozen" do
 
   it "still works if you are not in the app directory and specify --gemfile" do
     bundle! "install"
-    Dir.chdir tmp do
-      simulate_new_machine
-      bundle! :install,
-        forgotten_command_line_options(:gemfile => "#{tmp}/bundled_app/Gemfile",
-                                       :deployment => true,
-                                       :path => "vendor/bundle")
-    end
+    simulate_new_machine
+    bundle! :install,
+      forgotten_command_line_options(:gemfile => "#{tmp}/bundled_app/Gemfile",
+                                     :deployment => true,
+                                     :path => "vendor/bundle",
+                                     :dir => tmp)
     expect(the_bundle).to include_gems "rack 1.0"
   end
 

--- a/spec/install/gemfile/eval_gemfile_spec.rb
+++ b/spec/install/gemfile/eval_gemfile_spec.rb
@@ -28,8 +28,8 @@ RSpec.describe "bundle install with gemfile that uses eval_gemfile" do
 
   context "eval-ed Gemfile has relative-path gems" do
     before do
-      build_lib("a", :path => "gems/a")
-      create_file "nested/Gemfile-nested", <<-G
+      build_lib("a", :path => bundled_app("gems/a"))
+      create_file bundled_app("nested/Gemfile-nested"), <<-G
         gem "a", :path => "../gems/a"
       G
 

--- a/spec/install/gemfile/gemspec_spec.rb
+++ b/spec/install/gemfile/gemspec_spec.rb
@@ -120,18 +120,16 @@ RSpec.describe "bundle install from an existing gemspec" do
       s.add_development_dependency "rake", "=12.3.2"
     end
 
-    Dir.chdir(tmp.join("foo")) do
-      bundle "install"
-      # This should really be able to rely on $stderr, but, it's not written
-      # right, so we can't. In fact, this is a bug negation test, and so it'll
-      # ghost pass in future, and will only catch a regression if the message
-      # doesn't change. Exit codes should be used correctly (they can be more
-      # than just 0 and 1).
-      output = bundle("install --deployment")
-      expect(output).not_to match(/You have added to the Gemfile/)
-      expect(output).not_to match(/You have deleted from the Gemfile/)
-      expect(output).not_to match(/install in deployment mode after changing/)
-    end
+    bundle "install", :dir => tmp.join("foo")
+    # This should really be able to rely on $stderr, but, it's not written
+    # right, so we can't. In fact, this is a bug negation test, and so it'll
+    # ghost pass in future, and will only catch a regression if the message
+    # doesn't change. Exit codes should be used correctly (they can be more
+    # than just 0 and 1).
+    output = bundle("install --deployment", :dir => tmp.join("foo"))
+    expect(output).not_to match(/You have added to the Gemfile/)
+    expect(output).not_to match(/You have deleted from the Gemfile/)
+    expect(output).not_to match(/install in deployment mode after changing/)
   end
 
   it "should match a lockfile without needing to re-resolve" do
@@ -427,7 +425,7 @@ RSpec.describe "bundle install from an existing gemspec" do
           end
         end
 
-        build_lib "foo", :path => "." do |s|
+        build_lib "foo", :path => bundled_app do |s|
           if platform_specific_type == :runtime
             s.add_runtime_dependency dependency
           elsif platform_specific_type == :development

--- a/spec/install/gemfile/git_spec.rb
+++ b/spec/install/gemfile/git_spec.rb
@@ -481,7 +481,7 @@ RSpec.describe "bundle install with git sources" do
         gem "rack", :git => "#{lib_path("rack-0.8")}", :branch => "master"
       G
 
-      lockfile0 = File.read(bundled_app("Gemfile.lock"))
+      lockfile0 = File.read(bundled_app_lock)
 
       FileUtils.cp_r("#{lib_path("rack-0.8")}/.", lib_path("local-rack"))
       update_git "rack", "0.8", :path => lib_path("local-rack") do |s|
@@ -491,7 +491,7 @@ RSpec.describe "bundle install with git sources" do
       bundle %(config set local.rack #{lib_path("local-rack")})
       run "require 'rack'"
 
-      lockfile1 = File.read(bundled_app("Gemfile.lock"))
+      lockfile1 = File.read(bundled_app_lock)
       expect(lockfile1).not_to eq(lockfile0)
     end
 
@@ -503,7 +503,7 @@ RSpec.describe "bundle install with git sources" do
         gem "rack", :git => "#{lib_path("rack-0.8")}", :branch => "master"
       G
 
-      lockfile0 = File.read(bundled_app("Gemfile.lock"))
+      lockfile0 = File.read(bundled_app_lock)
 
       FileUtils.cp_r("#{lib_path("rack-0.8")}/.", lib_path("local-rack"))
       update_git "rack", "0.8", :path => lib_path("local-rack")
@@ -511,7 +511,7 @@ RSpec.describe "bundle install with git sources" do
       bundle %(config set local.rack #{lib_path("local-rack")})
       bundle :install
 
-      lockfile1 = File.read(bundled_app("Gemfile.lock"))
+      lockfile1 = File.read(bundled_app_lock)
       expect(lockfile1).not_to eq(lockfile0)
     end
 
@@ -965,7 +965,7 @@ RSpec.describe "bundle install with git sources" do
       gem "bar", :git => "#{lib_path("nested")}"
     G
 
-    expect(File.read(bundled_app("Gemfile.lock")).scan("GIT").size).to eq(1)
+    expect(File.read(bundled_app_lock).scan("GIT").size).to eq(1)
   end
 
   describe "switching sources" do
@@ -1025,8 +1025,8 @@ RSpec.describe "bundle install with git sources" do
       update_git "valim"
       new_revision = revision_for(lib_path("valim-1.0"))
 
-      old_lockfile = File.read(bundled_app("Gemfile.lock"))
-      lockfile(bundled_app("Gemfile.lock"), old_lockfile.gsub(/revision: #{old_revision}/, "revision: #{new_revision}"))
+      old_lockfile = File.read(bundled_app_lock)
+      lockfile(bundled_app_lock, old_lockfile.gsub(/revision: #{old_revision}/, "revision: #{new_revision}"))
 
       bundle "install"
 

--- a/spec/install/gemfile/git_spec.rb
+++ b/spec/install/gemfile/git_spec.rb
@@ -57,22 +57,18 @@ RSpec.describe "bundle install with git sources" do
     it "does not update the git source implicitly" do
       update_git "foo"
 
-      in_app_root2 do
-        install_gemfile bundled_app2("Gemfile"), <<-G
-          git "#{lib_path("foo-1.0")}" do
-            gem 'foo'
-          end
-        G
-      end
+      install_gemfile bundled_app2("Gemfile"), <<-G, :dir => bundled_app2
+        git "#{lib_path("foo-1.0")}" do
+          gem 'foo'
+        end
+      G
 
-      in_app_root do
-        run <<-RUBY
-          require 'foo'
-          puts "fail" if defined?(FOO_PREV_REF)
-        RUBY
+      run <<-RUBY
+        require 'foo'
+        puts "fail" if defined?(FOO_PREV_REF)
+      RUBY
 
-        expect(out).to be_empty
-      end
+      expect(out).to be_empty
     end
 
     it "sets up git gem executables on the path" do
@@ -130,22 +126,18 @@ RSpec.describe "bundle install with git sources" do
     it "still works after moving the application directory" do
       bundle "install --path vendor/bundle"
 
-      Dir.chdir root
       FileUtils.mv bundled_app, tmp("bundled_app.bck")
 
-      Dir.chdir tmp("bundled_app.bck")
-      expect(the_bundle).to include_gems "foo 1.0"
+      expect(the_bundle).to include_gems "foo 1.0", :dir => tmp("bundled_app.bck")
     end
 
     it "can still install after moving the application directory" do
       bundle "install --path vendor/bundle"
 
-      Dir.chdir root
       FileUtils.mv bundled_app, tmp("bundled_app.bck")
 
       update_git "foo", "1.1", :path => lib_path("foo-1.0")
 
-      Dir.chdir tmp("bundled_app.bck")
       gemfile tmp("bundled_app.bck/Gemfile"), <<-G
         source "#{file_uri_for(gem_repo1)}"
         git "#{lib_path("foo-1.0")}" do
@@ -155,9 +147,9 @@ RSpec.describe "bundle install with git sources" do
         gem "rack", "1.0"
       G
 
-      bundle "update foo"
+      bundle "update foo", :dir => tmp("bundled_app.bck")
 
-      expect(the_bundle).to include_gems "foo 1.1", "rack 1.0"
+      expect(the_bundle).to include_gems "foo 1.1", "rack 1.0", :dir => tmp("bundled_app.bck")
     end
   end
 
@@ -224,9 +216,7 @@ RSpec.describe "bundle install with git sources" do
         s.write("lib/foo.rb", "raise 'FAIL'")
       end
 
-      Dir.chdir(lib_path("foo-1.0")) do
-        `git update-ref -m "Bundler Spec!" refs/bundler/1 master~1`
-      end
+      sys_exec("git update-ref -m \"Bundler Spec!\" refs/bundler/1 master~1", :dir => lib_path("foo-1.0"))
 
       # want to ensure we don't fallback to HEAD
       update_git "foo", :path => lib_path("foo-1.0"), :branch => "rando" do |s|
@@ -260,9 +250,7 @@ RSpec.describe "bundle install with git sources" do
         s.write("lib/foo.rb", "raise 'FAIL'")
       end
 
-      Dir.chdir(lib_path("foo-1.0")) do
-        `git update-ref -m "Bundler Spec!" refs/bundler/1 master~1`
-      end
+      sys_exec("git update-ref -m \"Bundler Spec!\" refs/bundler/1 master~1", :dir => lib_path("foo-1.0"))
 
       # want to ensure we don't fallback to HEAD
       update_git "foo", :path => lib_path("foo-1.0"), :branch => "rando" do |s|
@@ -285,9 +273,7 @@ RSpec.describe "bundle install with git sources" do
     end
 
     it "does not download random non-head refs" do
-      Dir.chdir(lib_path("foo-1.0")) do
-        sys_exec!('git update-ref -m "Bundler Spec!" refs/bundler/1 master~1')
-      end
+      sys_exec("git update-ref -m \"Bundler Spec!\" refs/bundler/1 master~1", :dir => lib_path("foo-1.0"))
 
       bundle! "config set global_gem_cache true"
 
@@ -300,9 +286,7 @@ RSpec.describe "bundle install with git sources" do
       # ensure we also git fetch after cloning
       bundle! :update, :all => true
 
-      Dir.chdir(Dir[home(".bundle/cache/git/foo-*")].first) do
-        sys_exec("git ls-remote .")
-      end
+      sys_exec("git ls-remote .", :dir => Dir[home(".bundle/cache/git/foo-*")].first)
 
       expect(out).not_to include("refs/bundler/1")
     end
@@ -837,9 +821,7 @@ RSpec.describe "bundle install with git sources" do
     bundle "update", :all => true
     expect(the_bundle).to include_gems "forced 1.1"
 
-    Dir.chdir(lib_path("forced-1.0")) do
-      `git reset --hard HEAD^`
-    end
+    sys_exec("git reset --hard HEAD^", :dir => lib_path("forced-1.0"))
 
     bundle "update", :all => true
     expect(the_bundle).to include_gems "forced 1.0"
@@ -850,10 +832,8 @@ RSpec.describe "bundle install with git sources" do
     build_git "has_submodule", "1.0" do |s|
       s.add_dependency "submodule"
     end
-    Dir.chdir(lib_path("has_submodule-1.0")) do
-      sys_exec "git submodule add #{lib_path("submodule-1.0")} submodule-1.0"
-      `git commit -m "submodulator"`
-    end
+    sys_exec "git submodule add #{lib_path("submodule-1.0")} submodule-1.0", :dir => lib_path("has_submodule-1.0")
+    sys_exec "git commit -m \"submodulator\"", :dir => lib_path("has_submodule-1.0")
 
     install_gemfile <<-G
       git "#{lib_path("has_submodule-1.0")}" do
@@ -870,10 +850,8 @@ RSpec.describe "bundle install with git sources" do
     build_git "has_submodule", "1.0" do |s|
       s.add_dependency "submodule"
     end
-    Dir.chdir(lib_path("has_submodule-1.0")) do
-      sys_exec "git submodule add #{lib_path("submodule-1.0")} submodule-1.0"
-      `git commit -m "submodulator"`
-    end
+    sys_exec "git submodule add #{lib_path("submodule-1.0")} submodule-1.0", :dir => lib_path("has_submodule-1.0")
+    sys_exec "git commit -m \"submodulator\"", :dir => lib_path("has_submodule-1.0")
 
     install_gemfile <<-G
       git "#{lib_path("has_submodule-1.0")}", :submodules => true do
@@ -1172,16 +1150,15 @@ RSpec.describe "bundle install with git sources" do
       end
 
       2.times do |i|
-        Dir.chdir(git_reader.path) do
-          File.open("ext/foo.c", "w") do |file|
-            file.write <<-C
-              #include "ruby.h"
-              VALUE foo() { return INT2FIX(#{i}); }
-              void Init_foo() { rb_define_global_function("foo", &foo, 0); }
-            C
-          end
-          `git commit -m "commit for iteration #{i}" ext/foo.c`
+        File.open(git_reader.path.join("ext/foo.c"), "w") do |file|
+          file.write <<-C
+            #include "ruby.h"
+            VALUE foo() { return INT2FIX(#{i}); }
+            void Init_foo() { rb_define_global_function("foo", &foo, 0); }
+          C
         end
+        sys_exec("git commit -m \"commit for iteration #{i}\" ext/foo.c", :dir => git_reader.path)
+
         git_commit_sha = git_reader.ref_for("HEAD")
 
         install_gemfile <<-G

--- a/spec/install/gemfile/ruby_spec.rb
+++ b/spec/install/gemfile/ruby_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe "ruby requirement" do
   def locked_ruby_version
-    Bundler::RubyVersion.from_string(Bundler::LockfileParser.new(lockfile).ruby_version)
+    Bundler::RubyVersion.from_string(Bundler::LockfileParser.new(File.read(bundled_app_lock)).ruby_version)
   end
 
   # As discovered by https://github.com/bundler/bundler/issues/4147, there is
@@ -51,6 +51,7 @@ RSpec.describe "ruby requirement" do
       gem "rack"
     G
 
+    allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
     expect(locked_ruby_version).to eq(Bundler::RubyVersion.system)
 
     simulate_ruby_version "5100"
@@ -72,6 +73,7 @@ RSpec.describe "ruby requirement" do
       gem "rack"
     G
 
+    allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
     expect(locked_ruby_version).to eq(Bundler::RubyVersion.system)
 
     simulate_ruby_version "5100"

--- a/spec/install/gemfile/specific_platform_spec.rb
+++ b/spec/install/gemfile/specific_platform_spec.rb
@@ -58,6 +58,7 @@ RSpec.describe "bundle install with specific_platform enabled" do
 
     it "locks to both the specific darwin platform and ruby" do
       install_gemfile!(google_protobuf)
+      allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
       expect(the_bundle.locked_gems.platforms).to eq([pl("ruby"), pl("x86_64-darwin-15")])
       expect(the_bundle).to include_gem("google-protobuf 3.0.0.alpha.5.0.5.1 universal-darwin")
       expect(the_bundle.locked_gems.specs.map(&:full_name)).to eq(%w[
@@ -78,6 +79,7 @@ RSpec.describe "bundle install with specific_platform enabled" do
         source "#{file_uri_for(gem_repo2)}"
         gem "facter"
       G
+      allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
 
       expect(the_bundle.locked_gems.platforms).to eq([pl("ruby"), pl("x86_64-darwin-15")])
       expect(the_bundle).to include_gems("facter 2.4.6 universal-darwin", "CFPropertyList 1.0")
@@ -87,6 +89,10 @@ RSpec.describe "bundle install with specific_platform enabled" do
     end
 
     context "when adding a platform via lock --add_platform" do
+      before do
+        allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
+      end
+
       it "adds the foreign platform" do
         install_gemfile!(google_protobuf)
         bundle! "lock --add-platform=#{x64_mingw}"

--- a/spec/install/gemfile_spec.rb
+++ b/spec/install/gemfile_spec.rb
@@ -44,12 +44,10 @@ RSpec.describe "bundle install" do
     end
     it "uses the gemfile while in a subdirectory" do
       bundled_app("subdir").mkpath
-      Dir.chdir(bundled_app("subdir")) do
-        bundle "install"
-        bundle "list"
+      bundle "install", :dir => bundled_app("subdir")
+      bundle "list", :dir => bundled_app("subdir")
 
-        expect(out).to include("rack (1.0.0)")
-      end
+      expect(out).to include("rack (1.0.0)")
     end
   end
 

--- a/spec/install/gems/compact_index_spec.rb
+++ b/spec/install/gems/compact_index_spec.rb
@@ -1035,7 +1035,7 @@ Either installing with `--full-index` or running `bundle update rails` should fi
         gem "activemerchant"
       end
     G
-    gem_command! :uninstall, "activemerchant"
+    gem_command! "uninstall activemerchant"
     bundle! "update rails", :artifice => "compact_index"
     expect(lockfile.scan(/activemerchant \(/).size).to eq(1)
   end

--- a/spec/install/gems/compact_index_spec.rb
+++ b/spec/install/gems/compact_index_spec.rb
@@ -645,7 +645,7 @@ The checksum of /versions does not match the checksum provided by the server! So
     let(:user)     { "user" }
     let(:password) { "pass" }
     let(:basic_auth_source_uri) do
-      uri          = URI.parse(source_uri)
+      uri          = Bundler::URI.parse(source_uri)
       uri.user     = user
       uri.password = password
 

--- a/spec/install/gems/dependency_api_spec.rb
+++ b/spec/install/gems/dependency_api_spec.rb
@@ -615,7 +615,7 @@ RSpec.describe "gemcutter's dependency API" do
     let(:user)     { "user" }
     let(:password) { "pass" }
     let(:basic_auth_source_uri) do
-      uri          = URI.parse(source_uri)
+      uri          = Bundler::URI.parse(source_uri)
       uri.user     = user
       uri.password = password
 

--- a/spec/install/gems/flex_spec.rb
+++ b/spec/install/gems/flex_spec.rb
@@ -233,7 +233,7 @@ RSpec.describe "bundle flex_install" do
     it "does something" do
       expect do
         bundle "install"
-      end.not_to change { File.read(bundled_app("Gemfile.lock")) }
+      end.not_to change { File.read(bundled_app_lock) }
 
       expect(err).to include("rack = 0.9.1")
       expect(err).to include("locked at 1.0.0")

--- a/spec/install/gems/win32_spec.rb
+++ b/spec/install/gems/win32_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe "bundle install with win32-generated lockfile" do
   it "should read lockfile" do
-    File.open(bundled_app("Gemfile.lock"), "wb") do |f|
+    File.open(bundled_app_lock, "wb") do |f|
       f << "GEM\r\n"
       f << "  remote: #{file_uri_for(gem_repo1)}/\r\n"
       f << "  specs:\r\n"

--- a/spec/install/global_cache_spec.rb
+++ b/spec/install/global_cache_spec.rb
@@ -169,28 +169,26 @@ RSpec.describe "global gem caching" do
         expect(source_global_cache("rack-1.0.0.gem")).to exist
         expect(source_global_cache("activesupport-2.3.5.gem")).to exist
 
-        in_app_root2 do
-          create_file bundled_app2("gems.rb"), <<-G
-            source "#{source}"
-            gem "activesupport"
-          G
+        create_file bundled_app2("gems.rb"), <<-G
+          source "#{source}"
+          gem "activesupport"
+        G
 
-          # Neither gem is installed and both are in the global cache
-          expect(the_bundle).not_to include_gems "rack 1.0.0"
-          expect(the_bundle).not_to include_gems "activesupport 2.3.5"
-          expect(source_global_cache("rack-1.0.0.gem")).to exist
-          expect(source_global_cache("activesupport-2.3.5.gem")).to exist
+        # Neither gem is installed and both are in the global cache
+        expect(the_bundle).not_to include_gems "rack 1.0.0", :dir => bundled_app2
+        expect(the_bundle).not_to include_gems "activesupport 2.3.5", :dir => bundled_app2
+        expect(source_global_cache("rack-1.0.0.gem")).to exist
+        expect(source_global_cache("activesupport-2.3.5.gem")).to exist
 
-          # Install using the global cache instead of by downloading the .gem
-          # from the server
-          bundle! :install, :artifice => "compact_index_no_gem"
+        # Install using the global cache instead of by downloading the .gem
+        # from the server
+        bundle! :install, :artifice => "compact_index_no_gem", :dir => bundled_app2
 
-          # activesupport is installed and both are in the global cache
-          expect(the_bundle).not_to include_gems "rack 1.0.0"
-          expect(the_bundle).to include_gems "activesupport 2.3.5"
-          expect(source_global_cache("rack-1.0.0.gem")).to exist
-          expect(source_global_cache("activesupport-2.3.5.gem")).to exist
-        end
+        # activesupport is installed and both are in the global cache
+        expect(the_bundle).not_to include_gems "rack 1.0.0", :dir => bundled_app2
+        expect(the_bundle).to include_gems "activesupport 2.3.5", :dir => bundled_app2
+        expect(source_global_cache("rack-1.0.0.gem")).to exist
+        expect(source_global_cache("activesupport-2.3.5.gem")).to exist
       end
     end
   end

--- a/spec/install/path_spec.rb
+++ b/spec/install/path_spec.rb
@@ -22,10 +22,8 @@ RSpec.describe "bundle install" do
       dir = bundled_app("bun++dle")
       dir.mkpath
 
-      Dir.chdir(dir) do
-        bundle! :install, forgotten_command_line_options(:path => dir.join("vendor/bundle"))
-        expect(out).to include("installed into `./vendor/bundle`")
-      end
+      bundle! :install, forgotten_command_line_options(:path => dir.join("vendor/bundle")).merge(:dir => dir)
+      expect(out).to include("installed into `./vendor/bundle`")
 
       dir.rmtree
     end
@@ -54,30 +52,24 @@ RSpec.describe "bundle install" do
       before { bundle! "config set path_relative_to_cwd true" }
 
       it "installs the bundle relatively to current working directory", :bundler => "< 3" do
-        Dir.chdir(bundled_app.parent) do
-          bundle! "install --gemfile='#{bundled_app}/Gemfile' --path vendor/bundle"
-          expect(out).to include("installed into `./vendor/bundle`")
-          expect(bundled_app("../vendor/bundle")).to be_directory
-        end
+        bundle! "install --gemfile='#{bundled_app}/Gemfile' --path vendor/bundle", :dir => bundled_app.parent
+        expect(out).to include("installed into `./vendor/bundle`")
+        expect(bundled_app("../vendor/bundle")).to be_directory
         expect(the_bundle).to include_gems "rack 1.0.0"
       end
 
       it "installs the standalone bundle relative to the cwd" do
-        Dir.chdir(bundled_app.parent) do
-          bundle! :install, :gemfile => bundled_app_gemfile, :standalone => true
-          expect(out).to include("installed into `./bundled_app/bundle`")
-          expect(bundled_app("bundle")).to be_directory
-          expect(bundled_app("bundle/ruby")).to be_directory
-        end
+        bundle! :install, :gemfile => bundled_app_gemfile, :standalone => true, :dir => bundled_app.parent
+        expect(out).to include("installed into `./bundled_app/bundle`")
+        expect(bundled_app("bundle")).to be_directory
+        expect(bundled_app("bundle/ruby")).to be_directory
 
         bundle! "config unset path"
 
-        Dir.chdir(bundled_app("subdir").tap(&:mkpath)) do
-          bundle! :install, :gemfile => bundled_app_gemfile, :standalone => true
-          expect(out).to include("installed into `../bundle`")
-          expect(bundled_app("bundle")).to be_directory
-          expect(bundled_app("bundle/ruby")).to be_directory
-        end
+        bundle! :install, :gemfile => bundled_app_gemfile, :standalone => true, :dir => bundled_app("subdir").tap(&:mkpath)
+        expect(out).to include("installed into `../bundle`")
+        expect(bundled_app("bundle")).to be_directory
+        expect(bundled_app("bundle/ruby")).to be_directory
       end
     end
   end
@@ -137,9 +129,7 @@ RSpec.describe "bundle install" do
           set_bundle_path(type, "vendor")
 
           FileUtils.mkdir_p bundled_app("lol")
-          Dir.chdir(bundled_app("lol")) do
-            bundle! :install
-          end
+          bundle! :install, :dir => bundled_app("lol")
 
           expect(bundled_app("vendor", Bundler.ruby_scope, "gems/rack-1.0.0")).to be_directory
           expect(the_bundle).to include_gems "rack 1.0.0"
@@ -203,9 +193,7 @@ RSpec.describe "bundle install" do
 
   describe "to a file" do
     before do
-      in_app_root do
-        FileUtils.touch "bundle"
-      end
+      FileUtils.touch bundled_app("bundle")
     end
 
     it "reports the file exists" do

--- a/spec/install/path_spec.rb
+++ b/spec/install/path_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe "bundle install" do
 
       it "installs the standalone bundle relative to the cwd" do
         Dir.chdir(bundled_app.parent) do
-          bundle! :install, :gemfile => bundled_app("Gemfile"), :standalone => true
+          bundle! :install, :gemfile => bundled_app_gemfile, :standalone => true
           expect(out).to include("installed into `./bundled_app/bundle`")
           expect(bundled_app("bundle")).to be_directory
           expect(bundled_app("bundle/ruby")).to be_directory
@@ -73,7 +73,7 @@ RSpec.describe "bundle install" do
         bundle! "config unset path"
 
         Dir.chdir(bundled_app("subdir").tap(&:mkpath)) do
-          bundle! :install, :gemfile => bundled_app("Gemfile"), :standalone => true
+          bundle! :install, :gemfile => bundled_app_gemfile, :standalone => true
           expect(out).to include("installed into `../bundle`")
           expect(bundled_app("bundle")).to be_directory
           expect(bundled_app("bundle/ruby")).to be_directory

--- a/spec/lock/lockfile_spec.rb
+++ b/spec/lock/lockfile_spec.rb
@@ -1211,7 +1211,7 @@ RSpec.describe "the lockfile format" do
       gem "rack", "1.1"
     G
 
-    expect(bundled_app("Gemfile.lock")).not_to exist
+    expect(bundled_app_lock).not_to exist
     expect(err).to include "rack (= 1.0) and rack (= 1.1)"
   end
 
@@ -1222,7 +1222,7 @@ RSpec.describe "the lockfile format" do
       gem "rack", :git => "git://hubz.com"
     G
 
-    expect(bundled_app("Gemfile.lock")).not_to exist
+    expect(bundled_app_lock).not_to exist
     expect(err).to include "rack (>= 0) should come from an unspecified source and git://hubz.com (at master)"
   end
 
@@ -1378,7 +1378,7 @@ RSpec.describe "the lockfile format" do
   describe "a line ending" do
     def set_lockfile_mtime_to_known_value
       time = Time.local(2000, 1, 1, 0, 0, 0)
-      File.utime(time, time, bundled_app("Gemfile.lock"))
+      File.utime(time, time, bundled_app_lock)
     end
     before(:each) do
       build_repo2
@@ -1391,7 +1391,7 @@ RSpec.describe "the lockfile format" do
     end
 
     it "generates Gemfile.lock with \\n line endings" do
-      expect(File.read(bundled_app("Gemfile.lock"))).not_to match("\r\n")
+      expect(File.read(bundled_app_lock)).not_to match("\r\n")
       expect(the_bundle).to include_gems "rack 1.0"
     end
 
@@ -1399,8 +1399,8 @@ RSpec.describe "the lockfile format" do
       it "preserves Gemfile.lock \\n line endings" do
         update_repo2
 
-        expect { bundle "update", :all => true }.to change { File.mtime(bundled_app("Gemfile.lock")) }
-        expect(File.read(bundled_app("Gemfile.lock"))).not_to match("\r\n")
+        expect { bundle "update", :all => true }.to change { File.mtime(bundled_app_lock) }
+        expect(File.read(bundled_app_lock)).not_to match("\r\n")
         expect(the_bundle).to include_gems "rack 1.2"
       end
 
@@ -1408,12 +1408,12 @@ RSpec.describe "the lockfile format" do
         skip "needs to be adapted" if Gem.win_platform?
 
         update_repo2
-        win_lock = File.read(bundled_app("Gemfile.lock")).gsub(/\n/, "\r\n")
-        File.open(bundled_app("Gemfile.lock"), "wb") {|f| f.puts(win_lock) }
+        win_lock = File.read(bundled_app_lock).gsub(/\n/, "\r\n")
+        File.open(bundled_app_lock, "wb") {|f| f.puts(win_lock) }
         set_lockfile_mtime_to_known_value
 
-        expect { bundle "update", :all => true }.to change { File.mtime(bundled_app("Gemfile.lock")) }
-        expect(File.read(bundled_app("Gemfile.lock"))).to match("\r\n")
+        expect { bundle "update", :all => true }.to change { File.mtime(bundled_app_lock) }
+        expect(File.read(bundled_app_lock)).to match("\r\n")
         expect(the_bundle).to include_gems "rack 1.2"
       end
     end
@@ -1425,12 +1425,12 @@ RSpec.describe "the lockfile format" do
                    require 'bundler'
                    Bundler.setup
                  RUBY
-        end.not_to change { File.mtime(bundled_app("Gemfile.lock")) }
+        end.not_to change { File.mtime(bundled_app_lock) }
       end
 
       it "preserves Gemfile.lock \\n\\r line endings" do
-        win_lock = File.read(bundled_app("Gemfile.lock")).gsub(/\n/, "\r\n")
-        File.open(bundled_app("Gemfile.lock"), "wb") {|f| f.puts(win_lock) }
+        win_lock = File.read(bundled_app_lock).gsub(/\n/, "\r\n")
+        File.open(bundled_app_lock, "wb") {|f| f.puts(win_lock) }
         set_lockfile_mtime_to_known_value
 
         expect do
@@ -1438,7 +1438,7 @@ RSpec.describe "the lockfile format" do
                    require 'bundler'
                    Bundler.setup
                  RUBY
-        end.not_to change { File.mtime(bundled_app("Gemfile.lock")) }
+        end.not_to change { File.mtime(bundled_app_lock) }
       end
     end
   end

--- a/spec/other/platform_spec.rb
+++ b/spec/other/platform_spec.rb
@@ -298,7 +298,7 @@ G
         #{ruby_version_correct}
       G
 
-      expect(bundled_app("Gemfile.lock")).to exist
+      expect(bundled_app_lock).to exist
     end
 
     it "installs fine with any engine" do
@@ -310,7 +310,7 @@ G
           #{ruby_version_correct_engineless}
         G
 
-        expect(bundled_app("Gemfile.lock")).to exist
+        expect(bundled_app_lock).to exist
       end
     end
 
@@ -322,7 +322,7 @@ G
         #{ruby_version_correct_patchlevel}
       G
 
-      expect(bundled_app("Gemfile.lock")).to exist
+      expect(bundled_app_lock).to exist
     end
 
     it "doesn't install when the ruby version doesn't match" do
@@ -333,7 +333,7 @@ G
         #{ruby_version_incorrect}
       G
 
-      expect(bundled_app("Gemfile.lock")).not_to exist
+      expect(bundled_app_lock).not_to exist
       should_be_ruby_version_incorrect
     end
 
@@ -345,7 +345,7 @@ G
         #{engine_incorrect}
       G
 
-      expect(bundled_app("Gemfile.lock")).not_to exist
+      expect(bundled_app_lock).not_to exist
       should_be_engine_incorrect
     end
 
@@ -358,7 +358,7 @@ G
           #{engine_version_incorrect}
         G
 
-        expect(bundled_app("Gemfile.lock")).not_to exist
+        expect(bundled_app_lock).not_to exist
         should_be_engine_version_incorrect
       end
     end
@@ -371,7 +371,7 @@ G
         #{patchlevel_incorrect}
       G
 
-      expect(bundled_app("Gemfile.lock")).not_to exist
+      expect(bundled_app_lock).not_to exist
       should_be_patchlevel_incorrect
     end
   end
@@ -1051,10 +1051,10 @@ G
         #{ruby_version_correct}
       G
 
-      FileUtils.rm(bundled_app("Gemfile.lock"))
+      FileUtils.rm(bundled_app_lock)
 
       run "1"
-      expect(bundled_app("Gemfile.lock")).to exist
+      expect(bundled_app_lock).to exist
     end
 
     it "makes a Gemfile.lock if setup succeeds for any engine" do
@@ -1067,10 +1067,10 @@ G
           #{ruby_version_correct_engineless}
         G
 
-        FileUtils.rm(bundled_app("Gemfile.lock"))
+        FileUtils.rm(bundled_app_lock)
 
         run "1"
-        expect(bundled_app("Gemfile.lock")).to exist
+        expect(bundled_app_lock).to exist
       end
     end
 
@@ -1083,13 +1083,13 @@ G
         #{ruby_version_incorrect}
       G
 
-      FileUtils.rm(bundled_app("Gemfile.lock"))
+      FileUtils.rm(bundled_app_lock)
 
       ruby <<-R
         require 'bundler/setup'
       R
 
-      expect(bundled_app("Gemfile.lock")).not_to exist
+      expect(bundled_app_lock).not_to exist
       should_be_ruby_version_incorrect
     end
 
@@ -1102,13 +1102,13 @@ G
         #{engine_incorrect}
       G
 
-      FileUtils.rm(bundled_app("Gemfile.lock"))
+      FileUtils.rm(bundled_app_lock)
 
       ruby <<-R
         require 'bundler/setup'
       R
 
-      expect(bundled_app("Gemfile.lock")).not_to exist
+      expect(bundled_app_lock).not_to exist
       should_be_engine_incorrect
     end
 
@@ -1122,13 +1122,13 @@ G
           #{engine_version_incorrect}
         G
 
-        FileUtils.rm(bundled_app("Gemfile.lock"))
+        FileUtils.rm(bundled_app_lock)
 
         ruby <<-R
           require 'bundler/setup'
         R
 
-        expect(bundled_app("Gemfile.lock")).not_to exist
+        expect(bundled_app_lock).not_to exist
         should_be_engine_version_incorrect
       end
     end
@@ -1142,13 +1142,13 @@ G
         #{patchlevel_incorrect}
       G
 
-      FileUtils.rm(bundled_app("Gemfile.lock"))
+      FileUtils.rm(bundled_app_lock)
 
       ruby <<-R
         require 'bundler/setup'
       R
 
-      expect(bundled_app("Gemfile.lock")).not_to exist
+      expect(bundled_app_lock).not_to exist
       should_be_patchlevel_incorrect
     end
   end

--- a/spec/plugins/install_spec.rb
+++ b/spec/plugins/install_spec.rb
@@ -155,6 +155,10 @@ RSpec.describe "bundler plugin install" do
   end
 
   context "Gemfile eval" do
+    before do
+      allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
+    end
+
     it "installs plugins listed in gemfile" do
       gemfile <<-G
         source '#{file_uri_for(gem_repo2)}'
@@ -245,6 +249,7 @@ RSpec.describe "bundler plugin install" do
 
   describe "local plugin" do
     it "is installed when inside an app" do
+      allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
       gemfile ""
       bundle "plugin install foo --source #{file_uri_for(gem_repo2)}"
 
@@ -287,21 +292,16 @@ RSpec.describe "bundler plugin install" do
         end
 
         # outside the app
-        Dir.chdir tmp
-        bundle "plugin install fubar --source #{file_uri_for(gem_repo2)}"
+        bundle "plugin install fubar --source #{file_uri_for(gem_repo2)}", :dir => tmp
       end
 
       it "inside the app takes precedence over global plugin" do
-        Dir.chdir bundled_app
-
         bundle "shout"
         expect(out).to eq("local_one")
       end
 
       it "outside the app global plugin is used" do
-        Dir.chdir tmp
-
-        bundle "shout"
+        bundle "shout", :dir => tmp
         expect(out).to eq("global_one")
       end
     end

--- a/spec/plugins/source_spec.rb
+++ b/spec/plugins/source_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe "bundler source plugin" do
         end
       G
 
+      allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
       plugin_should_be_installed("bundler-source-psource")
     end
 
@@ -75,6 +76,7 @@ RSpec.describe "bundler source plugin" do
         end
 
         it "installs the explicit one" do
+          allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
           plugin_should_be_installed("another-psource")
         end
 
@@ -100,6 +102,7 @@ RSpec.describe "bundler source plugin" do
         end
 
         it "installs the default one" do
+          allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
           plugin_should_be_installed("bundler-source-psource")
         end
       end

--- a/spec/quality_es_spec.rb
+++ b/spec/quality_es_spec.rb
@@ -40,12 +40,10 @@ RSpec.describe "La biblioteca si misma" do
   it "mantiene la calidad de lenguaje de la documentación" do
     included = /ronn/
     error_messages = []
-    in_repo_root do
-      man_tracked_files.split("\x0").each do |filename|
-        next unless filename =~ included
-        error_messages << check_for_expendable_words(filename)
-        error_messages << check_for_specific_pronouns(filename)
-      end
+    man_tracked_files.split("\x0").each do |filename|
+      next unless filename =~ included
+      error_messages << check_for_expendable_words(filename)
+      error_messages << check_for_specific_pronouns(filename)
     end
     expect(error_messages.compact).to be_well_formed
   end
@@ -53,12 +51,10 @@ RSpec.describe "La biblioteca si misma" do
   it "mantiene la calidad de lenguaje de oraciones usadas en el código fuente" do
     error_messages = []
     exempt = /vendor/
-    in_repo_root do
-      lib_tracked_files.split("\x0").each do |filename|
-        next if filename =~ exempt
-        error_messages << check_for_expendable_words(filename)
-        error_messages << check_for_specific_pronouns(filename)
-      end
+    lib_tracked_files.split("\x0").each do |filename|
+      next if filename =~ exempt
+      error_messages << check_for_expendable_words(filename)
+      error_messages << check_for_specific_pronouns(filename)
     end
     expect(error_messages.compact).to be_well_formed
   end

--- a/spec/quality_es_spec.rb
+++ b/spec/quality_es_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "La biblioteca si misma" do
     included = /ronn/
     error_messages = []
     in_repo_root do
-      `git ls-files -z -- man`.split("\x0").each do |filename|
+      man_tracked_files.split("\x0").each do |filename|
         next unless filename =~ included
         error_messages << check_for_expendable_words(filename)
         error_messages << check_for_specific_pronouns(filename)

--- a/spec/quality_spec.rb
+++ b/spec/quality_spec.rb
@@ -107,12 +107,10 @@ RSpec.describe "The library itself" do
   it "has no malformed whitespace" do
     exempt = /\.gitmodules|fixtures|vendor|LICENSE|vcr_cassettes|rbreadline\.diff|\.txt$/
     error_messages = []
-    in_repo_root do
-      tracked_files.split("\x0").each do |filename|
-        next if filename =~ exempt
-        error_messages << check_for_tab_characters(filename)
-        error_messages << check_for_extra_spaces(filename)
-      end
+    tracked_files.split("\x0").each do |filename|
+      next if filename =~ exempt
+      error_messages << check_for_tab_characters(filename)
+      error_messages << check_for_extra_spaces(filename)
     end
     expect(error_messages.compact).to be_well_formed
   end
@@ -120,11 +118,9 @@ RSpec.describe "The library itself" do
   it "has no estraneous quotes" do
     exempt = /vendor|vcr_cassettes|LICENSE|rbreadline\.diff/
     error_messages = []
-    in_repo_root do
-      tracked_files.split("\x0").each do |filename|
-        next if filename =~ exempt
-        error_messages << check_for_straneous_quotes(filename)
-      end
+    tracked_files.split("\x0").each do |filename|
+      next if filename =~ exempt
+      error_messages << check_for_straneous_quotes(filename)
     end
     expect(error_messages.compact).to be_well_formed
   end
@@ -132,11 +128,9 @@ RSpec.describe "The library itself" do
   it "does not include any leftover debugging or development mechanisms" do
     exempt = %r{quality_spec.rb|support/helpers|vcr_cassettes|\.md|\.ronn|\.txt|\.5|\.1}
     error_messages = []
-    in_repo_root do
-      tracked_files.split("\x0").each do |filename|
-        next if filename =~ exempt
-        error_messages << check_for_debugging_mechanisms(filename)
-      end
+    tracked_files.split("\x0").each do |filename|
+      next if filename =~ exempt
+      error_messages << check_for_debugging_mechanisms(filename)
     end
     expect(error_messages.compact).to be_well_formed
   end
@@ -144,11 +138,9 @@ RSpec.describe "The library itself" do
   it "does not include any unresolved merge conflicts" do
     error_messages = []
     exempt = %r{lock/lockfile_spec|quality_spec|vcr_cassettes|\.ronn|lockfile_parser\.rb}
-    in_repo_root do
-      tracked_files.split("\x0").each do |filename|
-        next if filename =~ exempt
-        error_messages << check_for_git_merge_conflicts(filename)
-      end
+    tracked_files.split("\x0").each do |filename|
+      next if filename =~ exempt
+      error_messages << check_for_git_merge_conflicts(filename)
     end
     expect(error_messages.compact).to be_well_formed
   end
@@ -156,12 +148,10 @@ RSpec.describe "The library itself" do
   it "maintains language quality of the documentation" do
     included = /ronn/
     error_messages = []
-    in_repo_root do
-      man_tracked_files.split("\x0").each do |filename|
-        next unless filename =~ included
-        error_messages << check_for_expendable_words(filename)
-        error_messages << check_for_specific_pronouns(filename)
-      end
+    man_tracked_files.split("\x0").each do |filename|
+      next unless filename =~ included
+      error_messages << check_for_expendable_words(filename)
+      error_messages << check_for_specific_pronouns(filename)
     end
     expect(error_messages.compact).to be_well_formed
   end
@@ -169,12 +159,10 @@ RSpec.describe "The library itself" do
   it "maintains language quality of sentences used in source code" do
     error_messages = []
     exempt = /vendor|vcr_cassettes/
-    in_repo_root do
-      lib_tracked_files.split("\x0").each do |filename|
-        next if filename =~ exempt
-        error_messages << check_for_expendable_words(filename)
-        error_messages << check_for_specific_pronouns(filename)
-      end
+    lib_tracked_files.split("\x0").each do |filename|
+      next if filename =~ exempt
+      error_messages << check_for_expendable_words(filename)
+      error_messages << check_for_specific_pronouns(filename)
     end
     expect(error_messages.compact).to be_well_formed
   end
@@ -197,15 +185,13 @@ RSpec.describe "The library itself" do
     Bundler::Settings::NUMBER_KEYS.each {|k| all_settings[k] << "in Bundler::Settings::NUMBER_KEYS" }
     Bundler::Settings::ARRAY_KEYS.each {|k| all_settings[k] << "in Bundler::Settings::ARRAY_KEYS" }
 
-    in_repo_root do
-      key_pattern = /([a-z\._-]+)/i
-      lib_tracked_files.split("\x0").each do |filename|
-        each_line(filename) do |line, number|
-          line.scan(/Bundler\.settings\[:#{key_pattern}\]/).flatten.each {|s| all_settings[s] << "referenced at `#{filename}:#{number.succ}`" }
-        end
+    key_pattern = /([a-z\._-]+)/i
+    lib_tracked_files.split("\x0").each do |filename|
+      each_line(filename) do |line, number|
+        line.scan(/Bundler\.settings\[:#{key_pattern}\]/).flatten.each {|s| all_settings[s] << "referenced at `#{filename}:#{number.succ}`" }
       end
-      documented_settings = File.read("man/bundle-config.ronn")[/LIST OF AVAILABLE KEYS.*/m].scan(/^\* `#{key_pattern}`/).flatten
     end
+    documented_settings = File.read("man/bundle-config.ronn")[/LIST OF AVAILABLE KEYS.*/m].scan(/^\* `#{key_pattern}`/).flatten
 
     documented_settings.each do |s|
       all_settings.delete(s)
@@ -231,54 +217,48 @@ RSpec.describe "The library itself" do
   end
 
   it "ships the correct set of files" do
-    in_repo_root do
-      git_list = shipped_files.split("\x0")
+    git_list = shipped_files.split("\x0")
 
-      gem_list = Gem::Specification.load(gemspec.to_s).files
+    gem_list = Gem::Specification.load(gemspec.to_s).files
 
-      expect(git_list.to_set).to eq(gem_list.to_set)
-    end
+    expect(git_list.to_set).to eq(gem_list.to_set)
   end
 
   it "does not contain any warnings" do
-    in_repo_root do
-      exclusions = %w[
-        lib/bundler/capistrano.rb
-        lib/bundler/deployment.rb
-        lib/bundler/gem_tasks.rb
-        lib/bundler/vlad.rb
-        lib/bundler/templates/gems.rb
-      ]
-      files_to_require = lib_tracked_files.split("\x0").grep(/\.rb$/) - exclusions
-      files_to_require.reject! {|f| f.start_with?("lib/bundler/vendor") }
-      files_to_require.map! {|f| File.expand_path("../#{f}", __dir__) }
-      sys_exec!("ruby -w") do |input, _, _|
-        files_to_require.each do |f|
-          input.puts "require '#{f}'"
-        end
+    exclusions = %w[
+      lib/bundler/capistrano.rb
+      lib/bundler/deployment.rb
+      lib/bundler/gem_tasks.rb
+      lib/bundler/vlad.rb
+      lib/bundler/templates/gems.rb
+    ]
+    files_to_require = lib_tracked_files.split("\x0").grep(/\.rb$/) - exclusions
+    files_to_require.reject! {|f| f.start_with?("lib/bundler/vendor") }
+    files_to_require.map! {|f| File.expand_path("../#{f}", __dir__) }
+    sys_exec!("ruby -w") do |input, _, _|
+      files_to_require.each do |f|
+        input.puts "require '#{f}'"
       end
-
-      warnings = last_command.stdboth.split("\n")
-      # ignore warnings around deprecated Object#=~ method in RubyGems
-      warnings.reject! {|w| w =~ %r{rubygems\/version.rb.*deprecated\ Object#=~} }
-
-      expect(warnings).to be_well_formed
     end
+
+    warnings = last_command.stdboth.split("\n")
+    # ignore warnings around deprecated Object#=~ method in RubyGems
+    warnings.reject! {|w| w =~ %r{rubygems\/version.rb.*deprecated\ Object#=~} }
+
+    expect(warnings).to be_well_formed
   end
 
   it "does not use require internally, but require_relative" do
-    in_repo_root do
-      exempt = %r{templates/|vendor/}
-      all_bad_requires = []
-      lib_tracked_files.split("\x0").each do |filename|
-        next if filename =~ exempt
-        each_line(filename) do |line, number|
-          line.scan(/^ *require "bundler/).each { all_bad_requires << "#{filename}:#{number.succ}" }
-        end
+    exempt = %r{templates/|vendor/}
+    all_bad_requires = []
+    lib_tracked_files.split("\x0").each do |filename|
+      next if filename =~ exempt
+      each_line(filename) do |line, number|
+        line.scan(/^ *require "bundler/).each { all_bad_requires << "#{filename}:#{number.succ}" }
       end
-
-      expect(all_bad_requires).to be_empty, "#{all_bad_requires.size} internal requires that should use `require_relative`: #{all_bad_requires}"
     end
+
+    expect(all_bad_requires).to be_empty, "#{all_bad_requires.size} internal requires that should use `require_relative`: #{all_bad_requires}"
   end
 
 private

--- a/spec/quality_spec.rb
+++ b/spec/quality_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe "The library itself" do
     included = /ronn/
     error_messages = []
     in_repo_root do
-      `git ls-files -z -- man`.split("\x0").each do |filename|
+      man_tracked_files.split("\x0").each do |filename|
         next unless filename =~ included
         error_messages << check_for_expendable_words(filename)
         error_messages << check_for_specific_pronouns(filename)

--- a/spec/quality_spec.rb
+++ b/spec/quality_spec.rb
@@ -251,10 +251,10 @@ RSpec.describe "The library itself" do
       ]
       files_to_require = lib_tracked_files.split("\x0").grep(/\.rb$/) - exclusions
       files_to_require.reject! {|f| f.start_with?("lib/bundler/vendor") }
-      files_to_require.map! {|f| f.chomp(".rb") }
-      sys_exec!("ruby -w -Ilib") do |input, _, _|
+      files_to_require.map! {|f| File.expand_path("../#{f}", __dir__) }
+      sys_exec!("ruby -w") do |input, _, _|
         files_to_require.each do |f|
-          input.puts "require '#{f.sub(%r{\Alib/}, "")}'"
+          input.puts "require '#{f}'"
         end
       end
 

--- a/spec/runtime/executable_spec.rb
+++ b/spec/runtime/executable_spec.rb
@@ -44,14 +44,14 @@ RSpec.describe "Running bin/* commands" do
 
   it "uses the default ruby install name when shebang is not specified" do
     bundle! "binstubs rack"
-    expect(File.open("bin/rackup").gets).to eq("#!/usr/bin/env #{RbConfig::CONFIG["ruby_install_name"]}\n")
+    expect(File.open(bundled_app("bin/rackup")).gets).to eq("#!/usr/bin/env #{RbConfig::CONFIG["ruby_install_name"]}\n")
   end
 
   it "allows the name of the shebang executable to be specified" do
     skip "not created with custom name :/" if Gem.win_platform?
 
     bundle! "binstubs rack", :shebang => "ruby-foo"
-    expect(File.open("bin/rackup").gets).to eq("#!/usr/bin/env ruby-foo\n")
+    expect(File.open(bundled_app("bin/rackup")).gets).to eq("#!/usr/bin/env ruby-foo\n")
   end
 
   it "runs the bundled command when out of the bundle" do
@@ -63,10 +63,8 @@ RSpec.describe "Running bin/* commands" do
       s.executables = "rackup"
     end
 
-    Dir.chdir(tmp) do
-      gembin "rackup"
-      expect(out).to eq("1.0.0")
-    end
+    gembin "rackup", :dir => tmp
+    expect(out).to eq("1.0.0")
   end
 
   it "works with gems in path" do

--- a/spec/runtime/gem_tasks_spec.rb
+++ b/spec/runtime/gem_tasks_spec.rb
@@ -59,15 +59,12 @@ RSpec.describe "require 'bundler/gem_tasks'" do
 
   context "rake build when path has spaces" do
     before do
-      Dir.chdir(root)
       spaced_bundled_app = tmp.join("bundled app")
       FileUtils.mv bundled_app, spaced_bundled_app
-      Dir.chdir(spaced_bundled_app)
+      bundle! "exec rake build", :dir => spaced_bundled_app
     end
 
     it "still runs successfully" do
-      bundle! "exec rake build"
-
       expect(err).to be_empty
     end
   end

--- a/spec/runtime/gem_tasks_spec.rb
+++ b/spec/runtime/gem_tasks_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "require 'bundler/gem_tasks'" do
 
   it "includes the relevant tasks" do
     with_gem_path_as(Spec::Path.base_system_gems.to_s) do
-      sys_exec "#{rake} -T", "RUBYOPT" => "-I#{lib_dir}"
+      sys_exec "#{rake} -T", :env => { "RUBYOPT" => "-I#{lib_dir}" }
     end
 
     expect(err).to be_empty
@@ -47,7 +47,7 @@ RSpec.describe "require 'bundler/gem_tasks'" do
 
   it "defines a working `rake install` task" do
     with_gem_path_as(Spec::Path.base_system_gems.to_s) do
-      sys_exec "#{rake} install", "RUBYOPT" => "-I#{lib_dir}"
+      sys_exec "#{rake} install", :env => { "RUBYOPT" => "-I#{lib_dir}" }
     end
 
     expect(err).to be_empty

--- a/spec/runtime/inline_spec.rb
+++ b/spec/runtime/inline_spec.rb
@@ -233,16 +233,14 @@ RSpec.describe "bundler/inline#gemfile" do
          1.13.6
     G
 
-    in_app_root do
-      script <<-RUBY
-        gemfile do
-          source "#{file_uri_for(gem_repo1)}"
-          gem "rack"
-        end
+    script <<-RUBY
+      gemfile do
+        source "#{file_uri_for(gem_repo1)}"
+        gem "rack"
+      end
 
-        puts RACK
-      RUBY
-    end
+      puts RACK
+    RUBY
 
     expect(err).to be_empty
     expect(exitstatus).to be_zero if exitstatus
@@ -265,16 +263,14 @@ RSpec.describe "bundler/inline#gemfile" do
   it "installs inline gems when BUNDLE_GEMFILE is set to an empty string" do
     ENV["BUNDLE_GEMFILE"] = ""
 
-    in_app_root do
-      script <<-RUBY
-        gemfile do
-          source "#{file_uri_for(gem_repo1)}"
-          gem "rack"
-        end
+    script <<-RUBY
+      gemfile do
+        source "#{file_uri_for(gem_repo1)}"
+        gem "rack"
+      end
 
-        puts RACK
-      RUBY
-    end
+      puts RACK
+    RUBY
 
     expect(err).to be_empty
     expect(exitstatus).to be_zero if exitstatus

--- a/spec/runtime/load_spec.rb
+++ b/spec/runtime/load_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "Bundler.load" do
         source "#{file_uri_for(gem_repo1)}"
         gem "rack"
       G
+      allow(Bundler::SharedHelpers).to receive(:pwd).and_return(bundled_app)
     end
 
     it "provides a list of the env dependencies" do
@@ -32,6 +33,7 @@ RSpec.describe "Bundler.load" do
         gem "rack"
       G
       bundle! :install
+      allow(Bundler::SharedHelpers).to receive(:pwd).and_return(bundled_app)
     end
 
     it "provides a list of the env dependencies" do
@@ -101,7 +103,7 @@ RSpec.describe "Bundler.load" do
         source "#{file_uri_for(gem_repo1)}"
         gem "activerecord"
       G
-
+      allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
       Bundler.load.specs.each do |spec|
         expect(spec.to_yaml).not_to match(/^\s+source:/)
         expect(spec.to_yaml).not_to match(/^\s+groups:/)

--- a/spec/runtime/platform_spec.rb
+++ b/spec/runtime/platform_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe "Bundler.setup with multi platform stuff" do
   end
 
   it "allows specifying only-ruby-platform on windows with gemspec dependency" do
-    build_lib("foo", "1.0", :path => ".") do |s|
+    build_lib("foo", "1.0", :path => bundled_app) do |s|
       s.add_dependency "rack"
     end
 

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -489,15 +489,16 @@ RSpec.describe "Bundler.setup" do
     it "does not randomly change the path when specifying --path and the bundle directory becomes read only" do
       bundle! :install, forgotten_command_line_options(:path => "vendor/bundle")
 
-      with_read_only("**/*") do
+      with_read_only("#{bundled_app}/**/*") do
         expect(the_bundle).to include_gems "rack 1.0.0"
       end
     end
 
     it "finds git gem when default bundle path becomes read only" do
+      bundle "config set --local path .bundle"
       bundle "install"
 
-      with_read_only("#{Bundler.bundle_path}/**/*") do
+      with_read_only("#{bundled_app(".bundle")}/**/*") do
         expect(the_bundle).to include_gems "rack 1.0.0"
       end
     end
@@ -865,11 +866,9 @@ end
         gem 'foo', '1.2.3', :path => 'vendor/foo'
       G
 
-      Dir.chdir(bundled_app.parent) do
-        run <<-R, :env => { "BUNDLE_GEMFILE" => bundled_app_gemfile.to_s }
-          require 'foo'
-        R
-      end
+      run <<-R, :env => { "BUNDLE_GEMFILE" => bundled_app_gemfile.to_s }, :dir => bundled_app.parent
+        require 'foo'
+      R
       expect(err).to be_empty
     end
 
@@ -889,11 +888,9 @@ end
 
       bundle :install
 
-      Dir.chdir(bundled_app.parent) do
-        run <<-R, :env => { "BUNDLE_GEMFILE" => bundled_app_gemfile.to_s }
-          require 'foo'
-        R
-      end
+      run <<-R, :env => { "BUNDLE_GEMFILE" => bundled_app_gemfile.to_s }, :dir => bundled_app.parent
+        require 'foo'
+      R
 
       expect(err).to be_empty
     end

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -1375,7 +1375,7 @@ end
     end
 
     it "takes care of requiring rubygems" do
-      sys_exec("#{Gem.ruby} -I#{lib_dir} -e \"puts require('bundler/setup')\"", "RUBYOPT" => "--disable=gems")
+      sys_exec("#{Gem.ruby} -I#{lib_dir} -e \"puts require('bundler/setup')\"", :env => { "RUBYOPT" => "--disable=gems" })
 
       expect(last_command.stdboth).to eq("true")
     end

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -866,7 +866,7 @@ end
       G
 
       Dir.chdir(bundled_app.parent) do
-        run <<-R, :env => { "BUNDLE_GEMFILE" => bundled_app("Gemfile").to_s }
+        run <<-R, :env => { "BUNDLE_GEMFILE" => bundled_app_gemfile.to_s }
           require 'foo'
         R
       end
@@ -890,7 +890,7 @@ end
       bundle :install
 
       Dir.chdir(bundled_app.parent) do
-        run <<-R, :env => { "BUNDLE_GEMFILE" => bundled_app("Gemfile").to_s }
+        run <<-R, :env => { "BUNDLE_GEMFILE" => bundled_app_gemfile.to_s }
           require 'foo'
         R
       end

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -218,7 +218,7 @@ RSpec.describe "Bundler.setup" do
       Bundler.setup
     R
 
-    expect(bundled_app("Gemfile.lock")).not_to exist
+    expect(bundled_app_lock).not_to exist
   end
 
   it "doesn't change the Gemfile.lock if the setup fails" do
@@ -227,7 +227,7 @@ RSpec.describe "Bundler.setup" do
       gem "rack"
     G
 
-    lockfile = File.read(bundled_app("Gemfile.lock"))
+    lockfile = File.read(bundled_app_lock)
 
     gemfile <<-G
       source "#{file_uri_for(gem_repo1)}"
@@ -241,7 +241,7 @@ RSpec.describe "Bundler.setup" do
       Bundler.setup
     R
 
-    expect(File.read(bundled_app("Gemfile.lock"))).to eq(lockfile)
+    expect(File.read(bundled_app_lock)).to eq(lockfile)
   end
 
   it "makes a Gemfile.lock if setup succeeds" do
@@ -250,12 +250,12 @@ RSpec.describe "Bundler.setup" do
       gem "rack"
     G
 
-    File.read(bundled_app("Gemfile.lock"))
+    File.read(bundled_app_lock)
 
-    FileUtils.rm(bundled_app("Gemfile.lock"))
+    FileUtils.rm(bundled_app_lock)
 
     run "1"
-    expect(bundled_app("Gemfile.lock")).to exist
+    expect(bundled_app_lock).to exist
   end
 
   describe "$BUNDLE_GEMFILE" do
@@ -460,7 +460,7 @@ RSpec.describe "Bundler.setup" do
     it "provides a good exception if the lockfile is unavailable" do
       bundle "install"
 
-      FileUtils.rm(bundled_app("Gemfile.lock"))
+      FileUtils.rm(bundled_app_lock)
 
       break_git!
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -58,7 +58,6 @@ RSpec.configure do |config|
 
   config.bisect_runner = :shell
 
-  original_wd  = Dir.pwd
   original_env = ENV.to_hash
 
   config.expect_with :rspec do |c|
@@ -105,8 +104,6 @@ RSpec.configure do |config|
     reset!
     system_gems []
 
-    Dir.chdir(bundled_app)
-
     @command_executions = []
 
     Bundler.ui.silence { example.run }
@@ -119,8 +116,6 @@ RSpec.configure do |config|
         message
       end
     end
-
-    Dir.chdir(original_wd)
   end
 
   config.after :suite do

--- a/spec/support/builders.rb
+++ b/spec/support/builders.rb
@@ -394,7 +394,7 @@ module Spec
       @_build_repo = File.basename(path)
       yield
       with_gem_path_as Path.base_system_gems do
-        Dir.chdir(path) { gem_command! :generate_index }
+        gem_command! :generate_index, :dir => path
       end
     ensure
       @_build_path = nil
@@ -551,6 +551,11 @@ module Spec
         @files = {}
       end
 
+      def capture(cmd, dir)
+        output, _status = Open3.capture2e(cmd, :chdir => dir)
+        output
+      end
+
       def method_missing(*args, &blk)
         @spec.send(*args, &blk)
       end
@@ -660,14 +665,12 @@ module Spec
         path = options[:path] || _default_path
         source = options[:source] || "git@#{path}"
         super(options.merge(:path => path, :source => source))
-        Dir.chdir(path) do
-          `git init`
-          `git add *`
-          `git config user.email "lol@wut.com"`
-          `git config user.name "lolwut"`
-          `git config commit.gpgsign false`
-          `git commit -m "OMG INITIAL COMMIT"`
-        end
+        capture("git init", path)
+        capture("git add *", path)
+        capture("git config user.email \"lol@wut.com\"", path)
+        capture("git config user.name \"lolwut\"", path)
+        capture("git config commit.gpgsign false", path)
+        capture("git commit -m \"OMG INITIAL COMMIT\"", path)
       end
     end
 
@@ -675,15 +678,14 @@ module Spec
       def _build(options)
         path = options[:path] || _default_path
         super(options.merge(:path => path))
-        Dir.chdir(path) do
-          `git init --bare`
-        end
+        capture("git init --bare", path)
       end
     end
 
     class GitUpdater < LibBuilder
-      def silently(str)
-        `#{str} 2>#{Bundler::NULL}`
+      def silently(str, dir)
+        output, _error, _status = Open3.capture3(str, :chdir => dir)
+        output
       end
 
       def _build(options)
@@ -691,34 +693,32 @@ module Spec
         update_gemspec = options[:gemspec] || false
         source = options[:source] || "git@#{libpath}"
 
-        Dir.chdir(libpath) do
-          silently "git checkout master"
+        silently "git checkout master", libpath
 
-          if branch = options[:branch]
-            raise "You can't specify `master` as the branch" if branch == "master"
-            escaped_branch = Shellwords.shellescape(branch)
+        if branch = options[:branch]
+          raise "You can't specify `master` as the branch" if branch == "master"
+          escaped_branch = Shellwords.shellescape(branch)
 
-            if `git branch | grep #{escaped_branch}`.empty?
-              silently("git branch #{escaped_branch}")
-            end
-
-            silently("git checkout #{escaped_branch}")
-          elsif tag = options[:tag]
-            `git tag #{Shellwords.shellescape(tag)}`
-          elsif options[:remote]
-            silently("git remote add origin #{options[:remote]}")
-          elsif options[:push]
-            silently("git push origin #{options[:push]}")
+          if capture("git branch | grep #{escaped_branch}", libpath).empty?
+            silently("git branch #{escaped_branch}", libpath)
           end
 
-          current_ref = `git rev-parse HEAD`.strip
-          _default_files.keys.each do |path|
-            _default_files[path] += "\n#{Builders.constantize(name)}_PREV_REF = '#{current_ref}'"
-          end
-          super(options.merge(:path => libpath, :gemspec => update_gemspec, :source => source))
-          `git add *`
-          `git commit -m "BUMP"`
+          silently("git checkout #{escaped_branch}", libpath)
+        elsif tag = options[:tag]
+          capture("git tag #{Shellwords.shellescape(tag)}", libpath)
+        elsif options[:remote]
+          silently("git remote add origin #{options[:remote]}", libpath)
+        elsif options[:push]
+          silently("git push origin #{options[:push]}", libpath)
         end
+
+        current_ref = silently("git rev-parse HEAD", libpath).strip
+        _default_files.keys.each do |path|
+          _default_files[path] += "\n#{Builders.constantize(name)}_PREV_REF = '#{current_ref}'"
+        end
+        super(options.merge(:path => libpath, :gemspec => update_gemspec, :source => source))
+        capture("git add *", libpath)
+        capture("git commit -m \"BUMP\"", libpath)
       end
     end
 
@@ -739,7 +739,7 @@ module Spec
 
       def git(cmd)
         Bundler::SharedHelpers.with_clean_git_env do
-          Dir.chdir(@path) { `git #{cmd}`.strip }
+          Open3.capture2e("git #{cmd}", :chdir => path)[0].strip
         end
       end
     end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -128,7 +128,7 @@ module Spec
       end.join
 
       cmd = "#{sudo} #{Gem.ruby} #{load_path_str} #{requires_str} #{bundle_bin} #{cmd}#{args}"
-      sys_exec(cmd, env, &block)
+      sys_exec(cmd, { :env => env }, &block)
     end
     bang :bundle
 
@@ -155,9 +155,8 @@ module Spec
     end
 
     def ruby(ruby, options = {})
-      env = options.delete(:env) || {}
       lib_option = options[:no_lib] ? "" : " -I#{lib_dir}"
-      sys_exec(%(#{Gem.ruby}#{lib_option} -w -e #{ruby.shellescape}), env)
+      sys_exec(%(#{Gem.ruby}#{lib_option} -w -e #{ruby.shellescape}), options)
     end
     bang :ruby
 
@@ -189,7 +188,8 @@ module Spec
       "#{Gem.ruby} -S #{ENV["GEM_PATH"]}/bin/rake"
     end
 
-    def sys_exec(cmd, env = {})
+    def sys_exec(cmd, options = {})
+      env = options[:env] || {}
       command_execution = CommandExecution.new(cmd.to_s, Dir.pwd)
 
       require "open3"

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -180,8 +180,8 @@ module Spec
       ENV["RUBYOPT"] = old
     end
 
-    def gem_command(command, args = "")
-      sys_exec("#{Path.gem_bin} #{command} #{args}")
+    def gem_command(command)
+      sys_exec("#{Path.gem_bin} #{command}")
     end
     bang :gem_command
 
@@ -292,12 +292,12 @@ module Spec
     def install_gem(path)
       raise "OMG `#{path}` does not exist!" unless File.exist?(path)
 
-      gem_command! :install, "--no-document --ignore-dependencies '#{path}'"
+      gem_command! "install --no-document --ignore-dependencies '#{path}'"
     end
 
     def with_built_bundler
       with_root_gemspec do |gemspec|
-        in_repo_root { gem_command! :build, gemspec.to_s }
+        in_repo_root { gem_command! "build #{gemspec}" }
       end
 
       bundler_path = root + "bundler-#{Bundler::VERSION}.gem"
@@ -406,7 +406,7 @@ module Spec
       ENV["GEM_PATH"] = system_gem_path.to_s
 
       gems.each do |gem|
-        gem_command! :install, "--no-document #{gem}"
+        gem_command! "install --no-document #{gem}"
       end
       return unless block_given?
       begin

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -214,7 +214,7 @@ module Spec
     end
 
     def lockfile_should_be(expected)
-      expect(bundled_app("Gemfile.lock")).to have_lockfile(expected)
+      expect(bundled_app_lock).to have_lockfile(expected)
     end
 
     def gemfile_should_be(expected)

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -218,7 +218,7 @@ module Spec
     end
 
     def gemfile_should_be(expected)
-      expect(bundled_app("Gemfile")).to read_as(strip_whitespace(expected))
+      expect(bundled_app_gemfile).to read_as(strip_whitespace(expected))
     end
   end
 end

--- a/spec/support/path.rb
+++ b/spec/support/path.rb
@@ -96,6 +96,10 @@ module Spec
       bundled_app("vendor/cache/#{path}.gem")
     end
 
+    def bundled_app_lock
+      bundled_app("Gemfile.lock")
+    end
+
     def base_system_gems
       tmp.join("gems/base")
     end

--- a/spec/support/path.rb
+++ b/spec/support/path.rb
@@ -51,6 +51,12 @@ module Spec
       @lib_tracked_files ||= ruby_core? ? `git ls-files -z -- lib/bundler lib/bundler.rb` : `git ls-files -z -- lib`
     end
 
+    def man_tracked_files
+      skip "not in git working directory" unless git_root_dir?
+
+      @man_tracked_files ||= `git ls-files -z -- man`
+    end
+
     def tmp(*path)
       root.join("tmp", scope, *path)
     end

--- a/spec/support/path.rb
+++ b/spec/support/path.rb
@@ -96,6 +96,10 @@ module Spec
       bundled_app("vendor/cache/#{path}.gem")
     end
 
+    def bundled_app_gemfile
+      bundled_app("Gemfile")
+    end
+
     def bundled_app_lock
       bundled_app("Gemfile.lock")
     end

--- a/spec/support/path.rb
+++ b/spec/support/path.rb
@@ -48,13 +48,13 @@ module Spec
     def lib_tracked_files
       skip "not in git working directory" unless git_root_dir?
 
-      @lib_tracked_files ||= ruby_core? ? `git ls-files -z -- lib/bundler lib/bundler.rb` : `git ls-files -z -- lib`
+      @lib_tracked_files ||= ruby_core? ? sys_exec("git ls-files -z -- lib/bundler lib/bundler.rb", :dir => root) : sys_exec("git ls-files -z -- lib", :dir => root)
     end
 
     def man_tracked_files
       skip "not in git working directory" unless git_root_dir?
 
-      @man_tracked_files ||= `git ls-files -z -- man`
+      @man_tracked_files ||= sys_exec("git ls-files -z -- man", :dir => root)
     end
 
     def tmp(*path)
@@ -192,14 +192,6 @@ module Spec
       else
         @ruby_core
       end
-    end
-
-    def in_app_root
-      Dir.chdir(bundled_app) { yield }
-    end
-
-    def in_app_root2
-      Dir.chdir(bundled_app2) { yield }
     end
 
     def in_repo_root

--- a/spec/support/rubygems_version_manager.rb
+++ b/spec/support/rubygems_version_manager.rb
@@ -44,10 +44,8 @@ private
   def switch_local_copy_if_needed
     return unless local_copy_switch_needed?
 
-    Dir.chdir(local_copy_path) do
-      sys_exec!("git remote update")
-      sys_exec!("git checkout #{target_tag} --quiet")
-    end
+    sys_exec!("git remote update", :dir => local_copy_path)
+    sys_exec!("git checkout #{target_tag} --quiet", :dir => local_copy_path)
 
     ENV["RGV"] = local_copy_path.to_s
   end
@@ -65,9 +63,7 @@ private
   end
 
   def local_copy_tag
-    Dir.chdir(local_copy_path) do
-      sys_exec!("git rev-parse --abbrev-ref HEAD")
-    end
+    sys_exec!("git rev-parse --abbrev-ref HEAD", :dir => local_copy_path)
   end
 
   def local_copy_path

--- a/spec/update/gemfile_spec.rb
+++ b/spec/update/gemfile_spec.rb
@@ -38,12 +38,10 @@ RSpec.describe "bundle update" do
 
     it "uses the gemfile while in a subdirectory" do
       bundled_app("subdir").mkpath
-      Dir.chdir(bundled_app("subdir")) do
-        bundle! "update", :all => true
-        bundle "list"
+      bundle! "update", :all => true, :dir => bundled_app("subdir")
+      bundle "list", :dir => bundled_app("subdir")
 
-        expect(out).to include("rack (1.0.0)")
-      end
+      expect(out).to include("rack (1.0.0)")
     end
   end
 end

--- a/spec/update/git_spec.rb
+++ b/spec/update/git_spec.rb
@@ -131,10 +131,8 @@ RSpec.describe "bundle update" do
           s.add_dependency "submodule"
         end
 
-        Dir.chdir(lib_path("has_submodule-1.0")) do
-          sys_exec "git submodule add #{lib_path("submodule-1.0")} submodule-1.0"
-          `git commit -m "submodulator"`
-        end
+        sys_exec "git submodule add #{lib_path("submodule-1.0")} submodule-1.0", :dir => lib_path("has_submodule-1.0")
+        sys_exec "git commit -m \"submodulator\"", :dir => lib_path("has_submodule-1.0")
       end
 
       it "it unlocks the source when submodules are added to a git source" do
@@ -259,14 +257,12 @@ RSpec.describe "bundle update" do
 
       bundle "update --source foo"
 
-      in_app_root do
-        run <<-RUBY
-          require 'foo'
-          puts "WIN" if defined?(FOO_PREV_REF)
-        RUBY
+      run <<-RUBY
+        require 'foo'
+        puts "WIN" if defined?(FOO_PREV_REF)
+      RUBY
 
-        expect(out).to eq("WIN")
-      end
+      expect(out).to eq("WIN")
     end
 
     it "unlocks gems that were originally pulled in by the source" do


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that since we run parallel tests by default, our CI is much less stable even though specs are faster.

### What was your diagnosis of the problem?

My diagnosis was that our specs change folders back and forth for every test, and that's not thread safe.

### What is your fix for the problem, implemented in this PR?

My fix is to stop changing folders in the main process during our specs.

### Why did you choose this fix out of the possible options?

I chose this fix because it should improve stability of our specs.
