### PR TITLE
Load `CompactIndexClient` upfront during specs

### DIFF
--- a/spec/bundler/fetcher/compact_index_spec.rb
+++ b/spec/bundler/fetcher/compact_index_spec.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+# load CompactIndexClient upfront to prevent thread safety issues during parallel specs
+require "bundler/compact_index_client"
+
 RSpec.describe Bundler::Fetcher::CompactIndex do
   let(:downloader)  { double(:downloader) }
   let(:display_uri) { Bundler::URI("http://sampleuri.com") }


### PR DESCRIPTION


Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

The problem was failing CI:  https://github.com/rubygems/bundler/runs/386607433.

### What was your diagnosis of the problem?

My diagnosis was that it could be caused by autoloading not being thread safe. The `CompactIndexClient` constant is autoloaded. If two parallel threads try to autoload the constant at the same time, it could happen that one of them sees the constant in an incomplete state (no `initialize` method defined yet).

### What is your fix for the problem, implemented in this PR?

My fix is to load the constant upfront.

### Why did you choose this fix out of the possible options?

I chose this fix because even if I could stop autoloading the constant, I don't want to touch code in `lib` at the moment just to fix a testing issue.
