### PR TITLE
Use "Ruby" and "RubyGems" instead of "ruby" and "rubygems" with compact index

### DIFF
--- a/lib/bundler/compact_index_client/gem_parser.rb
+++ b/lib/bundler/compact_index_client/gem_parser.rb
@@ -54,10 +54,10 @@ module Bundler
         end
         ruby = raw_requirements.match(/\A(ruby):(.+)\z/)
         if ruby
-          requirements << [ruby[1], ruby[2].split(/\s*,\s*/)]
+          requirements << ["Ruby", ruby[2].split(/\s*,\s*/)]
         end
         if rubygems
-          requirements << [rubygems[1], rubygems[2].split(/\s*,\s*/)]
+          requirements << ["RubyGems", rubygems[2].split(/\s*,\s*/)]
         end
         requirements
       end

--- a/spec/bundler/compact_index_client/gem_parser_spec.rb
+++ b/spec/bundler/compact_index_client/gem_parser_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe Bundler::CompactIndexClient::GemParser do
           [],
           [
             ["checksum", [checksum]],
-            ["ruby", [">= 2.0"]],
+            ["Ruby", [">= 2.0"]],
           ],
         ]
         expect(parse(line)).to eq expected
@@ -131,7 +131,7 @@ RSpec.describe Bundler::CompactIndexClient::GemParser do
           [],
           [
             ["checksum", [checksum]],
-            ["ruby", [">= 2.2", "< 2.7.dev"]],
+            ["Ruby", [">= 2.2", "< 2.7.dev"]],
           ],
         ]
         expect(parse(line)).to eq expected
@@ -146,8 +146,8 @@ RSpec.describe Bundler::CompactIndexClient::GemParser do
           [],
           [
             ["checksum", [checksum]],
-            ["ruby", [">= 1.9", "< 2.7.dev"]],
-            ["rubygems", ["> 1.3.1"]],
+            ["Ruby", [">= 1.9", "< 2.7.dev"]],
+            ["RubyGems", ["> 1.3.1"]],
           ],
         ]
         expect(parse(line)).to eq expected
@@ -164,7 +164,7 @@ RSpec.describe Bundler::CompactIndexClient::GemParser do
           [],
           [
             ["checksum", [checksum]],
-            ["rubygems", ["> 1.3.1"]],
+            ["RubyGems", ["> 1.3.1"]],
           ],
         ]
         expect(parse(line)).to eq expected


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was "Ruby" requirement isn't used correctly on solving gems.

See also:

  * https://github.com/rubygems/bundler/pull/7522#issuecomment-572635007
  * https://github.com/rubygems/bundler/pull/7522#issuecomment-572850885

### What was your diagnosis of the problem?

My diagnosis was using "ruby" and "rubygems" is compact index isn't good. Because we use "Ruby" and "RubyGems" in other places.

See also #7554 for compact index content.

### What is your fix for the problem, implemented in this PR?

My fix uses "Ruby" and "RubyGems" explicitly for requirement keys instead of using keys in compact index directly.

### Why did you choose this fix out of the possible options?

I chose this fix because we already use "Ruby" and "RubyGems" in other places.
