### PR TITLE
Update references to old repo location

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -5,5 +5,5 @@ newPRWelcomeComment: |
 
   If you have any questions or concerns that you wish to ask, feel free to leave a comment in this PR or join our #bundler channel on [Slack](https://slack.bundler.io/).
 
-  For more information about contributing to the Bundler project feel free to review our [CONTRIBUTING](https://github.com/bundler/bundler/blob/master/doc/contributing/README.md) guide
+  For more information about contributing to the Bundler project feel free to review our [CONTRIBUTING](https://github.com/rubygems/bundler/blob/master/doc/contributing/README.md) guide
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -133,4 +133,4 @@ Sometimes, though, you need to get admins involved. Admins will do their best to
 
 This Code of Conduct is adapted from the [package.community Code of Conduct], adapted from the [WeAllJS Code of Conduct](https://wealljs.org/code-of-conduct), itself adapted from [Contributor Covenant](https://contributor-covenant.org) version 1.4, available at [https://contributor-covenant.org/version/1/4](https://contributor-covenant.org/version/1/4), as well as the LGBTQ in Technology Slack [Code of Conduct](https://lgbtq.technology/coc.html).
 
-Additional thanks to [Contributor Covenant](https://contributor-covenant.org) for the [default code of conduct](https://github.com/bundler/bundler/blob/master/lib/bundler/templates/newgem/CODE_OF_CONDUCT.md.tt) included in generated gems.
+Additional thanks to [Contributor Covenant](https://contributor-covenant.org) for the [default code of conduct](https://github.com/rubygems/bundler/blob/master/lib/bundler/templates/newgem/CODE_OF_CONDUCT.md.tt) included in generated gems.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Version     ](https://img.shields.io/gem/v/bundler.svg?style=flat)](https://rubygems.org/gems/bundler)
 [![Build Status](https://img.shields.io/travis/rubygems/bundler/master.svg?style=flat)](https://travis-ci.org/rubygems/bundler)
-[![Inline docs ](https://inch-ci.org/github/bundler/bundler.svg?style=flat)](https://inch-ci.org/github/bundler/bundler)
+[![Inline docs ](https://inch-ci.org/github/rubygems/bundler.svg?style=flat)](https://inch-ci.org/github/rubygems/bundler)
 [![Slack       ](https://bundler-slackin.herokuapp.com/badge.svg)](https://bundler-slackin.herokuapp.com)
 
 # Bundler: a gem to bundle gems
@@ -44,7 +44,7 @@ To get in touch with the Bundler core team and other Bundler users, please see [
 
 ### Contributing
 
-If you'd like to contribute to Bundler, that's awesome, and we <3 you. We've put together [the Bundler contributor guide](https://github.com/bundler/bundler/blob/master/doc/contributing/README.md) with all of the information you need to get started.
+If you'd like to contribute to Bundler, that's awesome, and we <3 you. We've put together [the Bundler contributor guide](https://github.com/rubygems/bundler/blob/master/doc/contributing/README.md) with all of the information you need to get started.
 
 If you'd like to request a substantial change to Bundler or to the Bundler documentation, refer to the [Bundler RFC process](https://github.com/bundler/rfcs) for more information.
 
@@ -57,8 +57,8 @@ While some Bundler contributors are compensated by Ruby Together, the project ma
 
 ### Code of Conduct
 
-Everyone interacting in the Bundler project's codebases, issue trackers, chat rooms, and mailing lists is expected to follow the [Bundler code of conduct](https://github.com/bundler/bundler/blob/master/CODE_OF_CONDUCT.md).
+Everyone interacting in the Bundler project's codebases, issue trackers, chat rooms, and mailing lists is expected to follow the [Bundler code of conduct](https://github.com/rubygems/bundler/blob/master/CODE_OF_CONDUCT.md).
 
 ### License
 
-Bundler is available under an [MIT License](https://github.com/bundler/bundler/blob/master/LICENSE.md).
+Bundler is available under an [MIT License](https://github.com/rubygems/bundler/blob/master/LICENSE.md).

--- a/bundler.gemspec
+++ b/bundler.gemspec
@@ -24,10 +24,10 @@ Gem::Specification.new do |s|
 
   if s.respond_to?(:metadata=)
     s.metadata = {
-      "bug_tracker_uri" => "https://github.com/bundler/bundler/issues",
-      "changelog_uri" => "https://github.com/bundler/bundler/blob/master/CHANGELOG.md",
+      "bug_tracker_uri" => "https://github.com/rubygems/bundler/issues",
+      "changelog_uri" => "https://github.com/rubygems/bundler/blob/master/CHANGELOG.md",
       "homepage_uri" => "https://bundler.io/",
-      "source_code_uri" => "https://github.com/bundler/bundler/",
+      "source_code_uri" => "https://github.com/rubygems/bundler/",
     }
   end
 

--- a/doc/POLICIES.md
+++ b/doc/POLICIES.md
@@ -68,7 +68,7 @@ Major version releases should be cut no more than once per year, ideally between
 
 ### Enforcement guidelines
 
-First off, Bundler's policies and enforcement of those policies are subsidiary to [Bundler's code of conduct](https://github.com/bundler/bundler/blob/master/CODE_OF_CONDUCT.md) in any case where they conflict. The first priority is treating human beings with respect and empathy, and figuring out project guidelines and sticking to them will always come after that.
+First off, Bundler's policies and enforcement of those policies are subsidiary to [Bundler's code of conduct](https://github.com/rubygems/bundler/blob/master/CODE_OF_CONDUCT.md) in any case where they conflict. The first priority is treating human beings with respect and empathy, and figuring out project guidelines and sticking to them will always come after that.
 
 When it comes to carrying out our own policies, we're all regular humans trying to do the best we can. There will probably be times when we don't stick to our policies or goals. If you notice a discrepancy between real-life actions and these policies and goals, please bring it up! We want to make sure that our actions and our policies line up, and that our policies exemplify our goals.
 

--- a/doc/contributing/COMMUNITY.md
+++ b/doc/contributing/COMMUNITY.md
@@ -2,9 +2,9 @@
 
 Community is an important part of all we do. If you'd like to be part of the Bundler community, you can jump right in and start helping make Bundler better for everyone who uses it.
 
-It would be tremendously helpful to have more people answering questions about Bundler (and often simply about [RubyGems](https://github.com/rubygems/rubygems) or Ruby itself) in our [issue tracker](https://github.com/bundler/bundler/issues) or on [Stack Overflow](https://stackoverflow.com/questions/tagged/bundler).
+It would be tremendously helpful to have more people answering questions about Bundler (and often simply about [RubyGems](https://github.com/rubygems/rubygems) or Ruby itself) in our [issue tracker](https://github.com/rubygems/bundler/issues) or on [Stack Overflow](https://stackoverflow.com/questions/tagged/bundler).
 
-Additional documentation and explanation is always helpful, too. If you have any suggestions for the Bundler website [bundler.io](https://bundler.io), we would absolutely love it if you opened an issue or pull request on the [bundler-site](https://github.com/bundler/bundler-site) repository.
+Additional documentation and explanation is always helpful, too. If you have any suggestions for the Bundler website [bundler.io](https://bundler.io), we would absolutely love it if you opened an issue or pull request on the [bundler-site](https://github.com/rubygems/bundler-site) repository.
 
 Sharing your experiences and discoveries by writing them up is a valuable way to help others who have similar problems or experiences in the future. You can write a blog post, create an example and commit it to GitHub, take screenshots, or make videos.
 

--- a/doc/contributing/HOW_YOU_CAN_HELP.md
+++ b/doc/contributing/HOW_YOU_CAN_HELP.md
@@ -19,7 +19,7 @@ Generally, great ways to get started helping out with Bundler are:
   - closing issues that are not complete
   - adding a failing test for reproducible [reported bugs](https://github.com/rubygems/bundler/issues)
   - reviewing [pull requests](https://github.com/rubygems/bundler/pulls) and suggesting improvements
-  - improving existing code, including suggestions from [PullReview](https://www.pullreview.com/github/bundler/bundler/reviews/master) or [CodeClimate](https://codeclimate.com/github/bundler/bundler)
+  - improving existing code, including suggestions from [CodeClimate](https://codeclimate.com/github/bundler/bundler)
   - writing code (no patch is too small! fix typos or bad whitespace)
     - get started setting up your dev environment with [these instructions](../development/SETUP.md)
   - backfilling [unit tests](https://github.com/rubygems/bundler/tree/master/spec/bundler) for modules that lack coverage.

--- a/doc/contributing/HOW_YOU_CAN_HELP.md
+++ b/doc/contributing/HOW_YOU_CAN_HELP.md
@@ -6,22 +6,22 @@ If at any point you get stuck, here's how to [get in touch with the Bundler team
 
 ## First contribution suggestions
 
-We track [small bugs and features](https://github.com/bundler/bundler/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) so that anyone who wants to help can start with something that's not too overwhelming.
+We track [small bugs and features](https://github.com/rubygems/bundler/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) so that anyone who wants to help can start with something that's not too overwhelming.
 
 Generally, great ways to get started helping out with Bundler are:
 
   - using prerelease versions (run `gem install bundler --pre`)
-  - [reporting bugs you encounter or suggesting new features](https://github.com/bundler/bundler/issues/new)
+  - [reporting bugs you encounter or suggesting new features](https://github.com/rubygems/bundler/issues/new)
     - see our [issues guide](ISSUES.md) for help on filing issues
     - see the [new features documentation](../development/NEW_FEATURES.md) for more
   - adding to or editing [the Bundler documentation website](https://bundler.io) and [Bundler man pages](https://bundler.io/man/bundle.1.html)
   - [checking issues for completeness](BUG_TRIAGE.md)
   - closing issues that are not complete
-  - adding a failing test for reproducible [reported bugs](https://github.com/bundler/bundler/issues)
-  - reviewing [pull requests](https://github.com/bundler/bundler/pulls) and suggesting improvements
+  - adding a failing test for reproducible [reported bugs](https://github.com/rubygems/bundler/issues)
+  - reviewing [pull requests](https://github.com/rubygems/bundler/pulls) and suggesting improvements
   - improving existing code, including suggestions from [PullReview](https://www.pullreview.com/github/bundler/bundler/reviews/master) or [CodeClimate](https://codeclimate.com/github/bundler/bundler)
   - writing code (no patch is too small! fix typos or bad whitespace)
     - get started setting up your dev environment with [these instructions](../development/SETUP.md)
-  - backfilling [unit tests](https://github.com/bundler/bundler/tree/master/spec/bundler) for modules that lack coverage.
+  - backfilling [unit tests](https://github.com/rubygems/bundler/tree/master/spec/bundler) for modules that lack coverage.
 
 If nothing on those lists looks good, [talk to us](https://slack.bundler.io/), and we'll figure out what you can help with. We can absolutely use your help, no matter what level of programming skill you have at the moment.

--- a/doc/contributing/ISSUES.md
+++ b/doc/contributing/ISSUES.md
@@ -46,6 +46,6 @@ If your version of Bundler does not have the `bundle env` command, then please i
 
 If you have either `rubygems-bundler` or `open_gem` installed, please try removing them and then following the troubleshooting steps above before opening a new ticket.
 
-[Create a gist](https://gist.github.com) containing all of that information, then visit the [Bundler issue tracker](https://github.com/bundler/bundler/issues) and [create a ticket](https://github.com/bundler/bundler/issues/new) describing your problem and linking to your gist.
+[Create a gist](https://gist.github.com) containing all of that information, then visit the [Bundler issue tracker](https://github.com/rubygems/bundler/issues) and [create a ticket](https://github.com/rubygems/bundler/issues/new) describing your problem and linking to your gist.
 
 Thanks for reporting issues and helping make Bundler better!

--- a/doc/contributing/README.md
+++ b/doc/contributing/README.md
@@ -4,11 +4,11 @@ Thank you for your interest in making Bundler better! We welcome contributions f
 
 Before submitting a contribution, read through the following guidelines:
 
-* [Bundler Code of Conduct](https://github.com/bundler/bundler/blob/master/CODE_OF_CONDUCT.md) (By participating in Bundler, you agree to abide by the terms laid out in the CoC.)
-* [Issue Reporting Guidelines](https://github.com/bundler/bundler/blob/master/doc/contributing/ISSUES.md)
-* [Pull Request Guidelines](https://github.com/bundler/bundler/blob/master/doc/development/PULL_REQUESTS.md)
+* [Bundler Code of Conduct](https://github.com/rubygems/bundler/blob/master/CODE_OF_CONDUCT.md) (By participating in Bundler, you agree to abide by the terms laid out in the CoC.)
+* [Issue Reporting Guidelines](https://github.com/rubygems/bundler/blob/master/doc/contributing/ISSUES.md)
+* [Pull Request Guidelines](https://github.com/rubygems/bundler/blob/master/doc/development/PULL_REQUESTS.md)
 
-And be sure to [set up your development environment](https://github.com/bundler/bundler/blob/master/doc/development/SETUP.md).
+And be sure to [set up your development environment](https://github.com/rubygems/bundler/blob/master/doc/development/SETUP.md).
 
 ## Feature Requests
 
@@ -18,11 +18,11 @@ To request substantial changes to Bundler and/or Bundler documentation, please r
 
 Here are the different ways you can start contributing to the Bundler project:
 
-* [First contribution suggestions](https://github.com/bundler/bundler/blob/master/doc/contributing/HOW_YOU_CAN_HELP.md)
-* [Adding new features](https://github.com/bundler/bundler/blob/master/doc/development/NEW_FEATURES.md)
-* [Triaging bugs](https://github.com/bundler/bundler/blob/master/doc/contributing/BUG_TRIAGE.md)
-* [Writing documentation](https://github.com/bundler/bundler/blob/master/doc/documentation/WRITING.md)
-* [Community engagement](https://github.com/bundler/bundler/blob/master/doc/contributing/COMMUNITY.md)
+* [First contribution suggestions](https://github.com/rubygems/bundler/blob/master/doc/contributing/HOW_YOU_CAN_HELP.md)
+* [Adding new features](https://github.com/rubygems/bundler/blob/master/doc/development/NEW_FEATURES.md)
+* [Triaging bugs](https://github.com/rubygems/bundler/blob/master/doc/contributing/BUG_TRIAGE.md)
+* [Writing documentation](https://github.com/rubygems/bundler/blob/master/doc/documentation/WRITING.md)
+* [Community engagement](https://github.com/rubygems/bundler/blob/master/doc/contributing/COMMUNITY.md)
 
 ## Supporting Bundler
 

--- a/doc/development/NEW_FEATURES.md
+++ b/doc/development/NEW_FEATURES.md
@@ -2,7 +2,7 @@
 
 If you would like to add a new feature to Bundler, please follow these steps:
 
-  1. [Create an issue](https://github.com/bundler/bundler/issues/new) with the [`feature-request` label](https://github.com/bundler/bundler/labels/type:%20feature-request) to discuss your feature.
+  1. [Create an issue](https://github.com/rubygems/bundler/issues/new) with the [`feature-request` label](https://github.com/rubygems/bundler/labels/type:%20feature-request) to discuss your feature.
   2. Base your commits on the master branch, since we follow [SemVer](https://semver.org) and don't add new features to old releases.
   3. Commit the code and at least one test covering your changes to a feature branch in your fork.
   4. Send us a [pull request](PULL_REQUESTS.md) from your feature branch.

--- a/doc/development/PULL_REQUESTS.md
+++ b/doc/development/PULL_REQUESTS.md
@@ -29,7 +29,7 @@ Ex. For a pull request that changes something with `bundle update`, you might ru
 
 Please ensure that the commit messages included in the pull request __do not__ have the following:
   - `@tag` GitHub user or team references (ex. `@indirect` or `@bundler/core`)
-  - `#id` references to issues or pull requests (ex. `#43` or `bundler/bundler-site#12`)
+  - `#id` references to issues or pull requests (ex. `#43` or `rubygems/bundler-site#12`)
 
 If you want to use these mechanisms, please instead include them in the pull request description. This prevents multiple notifications or references being created on commit rebases or pull request/branch force pushes.
 

--- a/doc/development/SETUP.md
+++ b/doc/development/SETUP.md
@@ -2,7 +2,7 @@
 
 Bundler doesn't use a Gemfile to list development dependencies, because when we tried it we couldn't tell if we were awake or it was just another level of dreams. To work on Bundler, you'll probably want to do a couple of things:
 
-1. [Fork the Bundler repo](https://github.com/bundler/bundler), and clone the fork onto your machine. ([Follow this tutorial](https://help.github.com/articles/fork-a-repo/) for instructions on forking a repo.)
+1. [Fork the Bundler repo](https://github.com/rubygems/bundler), and clone the fork onto your machine. ([Follow this tutorial](https://help.github.com/articles/fork-a-repo/) for instructions on forking a repo.)
 
 2. Install `groff-base` and `graphviz` packages using your package manager:
 

--- a/doc/documentation/README.md
+++ b/doc/documentation/README.md
@@ -7,12 +7,12 @@ Currently, Bundler has two main sources of documentation:
 1. built-in `help` (including usage information and man pages)
 2. [Bundler documentation site](https://bundler.io)
 
-If you have a suggestion or proposed change for [bundler.io](https://bundler.io), please open an issue or send a pull request to the [bundler-site](https://github.com/bundler/bundler-site) repository.
+If you have a suggestion or proposed change for [bundler.io](https://bundler.io), please open an issue or send a pull request to the [bundler-site](https://github.com/rubygems/bundler-site) repository.
 
 Not sure where to write documentation? In general, follow these guidelines:
 
 * For an explanation of a specific Bundler command (ex: `bundle clean`): make changes to the man pages
-* For longer explanations or usage guides (ex: "Using Bundler with Rails"): create new documentation within the [bundler-site](https://github.com/bundler/bundler-site) repository
+* For longer explanations or usage guides (ex: "Using Bundler with Rails"): create new documentation within the [bundler-site](https://github.com/rubygems/bundler-site) repository
 
 If you are unsure where to begin, ping [@feministy](https://github.com/feministy) or [@indirect](https://github.com/indirect) in the Bundler Slack ([get an invite here](../contributing/GETTING_HELP.md)).
 

--- a/doc/documentation/WRITING.md
+++ b/doc/documentation/WRITING.md
@@ -55,11 +55,11 @@ $ bin/rspec ./spec/quality_spec.rb
 
 # Writing docs for [the Bundler documentation site](https://bundler.io)
 
-If you'd like to submit a pull request for any of the primary commands or utilities on [the Bundler documentation site](https://bundler.io), please follow the instructions above for writing documentation for man pages from the `bundler/bundler` repository. They are the same in each case.
+If you'd like to submit a pull request for any of the primary commands or utilities on [the Bundler documentation site](https://bundler.io), please follow the instructions above for writing documentation for man pages from the `rubygems/bundler` repository. They are the same in each case.
 
-Note: Editing `.ronn` files from the `bundler/bundler` repository for the primary commands and utilities documentation is all you need 🎉. There is no need to manually change anything in the `bundler/bundler-site` repository, because the man pages and the docs for primary commands and utilities on [the Bundler documentation site](https://bundler.io) are one in the same. They are generated automatically from the `bundler/bundler` repository's `.ronn` files from the `rake man/build` command. In other words, after updating `.ronn` file and running `rake man/build` in `bundler`, `.ronn` files map to the auto-generated files in the `source/man` directory of `bundler-site`.
+Note: Editing `.ronn` files from the `rubygems/bundler` repository for the primary commands and utilities documentation is all you need 🎉. There is no need to manually change anything in the `rubygems/bundler-site` repository, because the man pages and the docs for primary commands and utilities on [the Bundler documentation site](https://bundler.io) are one in the same. They are generated automatically from the `rubygems/bundler` repository's `.ronn` files from the `rake man/build` command. In other words, after updating `.ronn` file and running `rake man/build` in `bundler`, `.ronn` files map to the auto-generated files in the `source/man` directory of `bundler-site`.
 
-Additionally, if you'd like to add a guide or tutorial: in the `bundler/bundler-site` repository, go to `/bundler-site/source/current_version_of_bundler/guides` and add [a new Markdown file](https://guides.github.com/features/mastering-markdown/) (with an extension ending in `.md`). Be sure to correctly format the title of your new guide, like so:
+Additionally, if you'd like to add a guide or tutorial: in the `rubygems/bundler-site` repository, go to `/bundler-site/source/current_version_of_bundler/guides` and add [a new Markdown file](https://guides.github.com/features/mastering-markdown/) (with an extension ending in `.md`). Be sure to correctly format the title of your new guide, like so:
 ```
 ---
 title: RubyGems.org SSL/TLS Troubleshooting Guide

--- a/doc/playbooks/RELEASING.md
+++ b/doc/playbooks/RELEASING.md
@@ -39,9 +39,9 @@ When we cherry-pick, we cherry-pick the merge commits using the following comman
 $ git cherry-pick -m 1 MERGE_COMMIT_SHAS
 ```
 
-For example, for PR [#5029](https://github.com/bundler/bundler/pull/5029), we
-cherry picked commit [dd6aef9](https://github.com/bundler/bundler/commit/dd6aef97a5f2e7173f406267256a8c319d6134ab),
-not [4fe9291](https://github.com/bundler/bundler/commit/4fe92919f51e3463f0aad6fa833ab68044311f03)
+For example, for PR [#5029](https://github.com/rubygems/bundler/pull/5029), we
+cherry picked commit [dd6aef9](https://github.com/rubygems/bundler/commit/dd6aef97a5f2e7173f406267256a8c319d6134ab),
+not [4fe9291](https://github.com/rubygems/bundler/commit/4fe92919f51e3463f0aad6fa833ab68044311f03)
 using:
 
 ```bash
@@ -95,7 +95,7 @@ Here's the checklist for releasing new minor versions:
 Wait! You're not done yet! After your prelease looks good:
 
 * [ ] Update `version.rb` to a final version (i.e. 1.12.0)
-* [ ] In the [bundler/bundler-site](https://github.com/bundler/bundler-site) repo,
+* [ ] In the [rubygems/bundler-site](https://github.com/rubygems/bundler-site) repo,
   copy the previous version's docs to create a new version (e.g. `cp -r v1.11 v1.12`)
 * [ ] Update the new docs as needed, paying special attention to the "What's new"
   page for this version

--- a/doc/playbooks/TEAM_CHANGES.md
+++ b/doc/playbooks/TEAM_CHANGES.md
@@ -25,7 +25,7 @@ Interested in adding someone to the team? Here's the process.
 
 ## Removing a team member
 
-When the conditions in [POLICIES](https://github.com/bundler/bundler/blob/master/doc/POLICIES.md#maintainer-team-guidelines) are met, or when team members choose to retire, here's how to remove someone from the team.
+When the conditions in [POLICIES](https://github.com/rubygems/bundler/blob/master/doc/POLICIES.md#maintainer-team-guidelines) are met, or when team members choose to retire, here's how to remove someone from the team.
 
 - Remove them from the owners list on RubyGems.org by running
   ```
@@ -36,8 +36,8 @@ When the conditions in [POLICIES](https://github.com/bundler/bundler/blob/master
 - Remove them from the [maintainers team][org_team] on GitHub
 - Remove them from the maintainers Slack channel
 
-[policies]: https://github.com/bundler/bundler/blob/master/doc/POLICIES.md#bundler-policies
+[policies]: https://github.com/rubygems/bundler/blob/master/doc/POLICIES.md#bundler-policies
 [org_team]: https://github.com/orgs/bundler/teams/maintainers/members
 [team]: https://bundler.io/contributors.html
-[maintainers]: https://github.com/bundler/bundler-site/blob/02483d3f79f243774722b3fc18a471ca77b1c424/source/contributors.html.haml#L25
-[list]: https://github.com/bundler/bundler-site/blob/02483d3f79f243774722b3fc18a471ca77b1c424/lib/tasks/contributors.rake#L8
+[maintainers]: https://github.com/rubygems/bundler-site/blob/02483d3f79f243774722b3fc18a471ca77b1c424/source/contributors.html.haml#L25
+[list]: https://github.com/rubygems/bundler-site/blob/02483d3f79f243774722b3fc18a471ca77b1c424/lib/tasks/contributors.rake#L8

--- a/lib/bundler/remote_specification.rb
+++ b/lib/bundler/remote_specification.rb
@@ -76,7 +76,7 @@ module Bundler
         deps = method_missing(:dependencies)
 
         # allow us to handle when the specs dependencies are an array of array of string
-        # see https://github.com/bundler/bundler/issues/5797
+        # see https://github.com/rubygems/bundler/issues/5797
         deps = deps.map {|d| d.is_a?(Gem::Dependency) ? d : Gem::Dependency.new(*d) }
 
         deps

--- a/lib/bundler/rubygems_integration.rb
+++ b/lib/bundler/rubygems_integration.rb
@@ -346,7 +346,7 @@ module Bundler
           raise e
         end
 
-        # backwards compatibility shim, see https://github.com/bundler/bundler/issues/5102
+        # backwards compatibility shim, see https://github.com/rubygems/bundler/issues/5102
         kernel_class.send(:public, :gem) if Bundler.feature_flag.setup_makes_kernel_gem_public?
       end
     end

--- a/spec/bundler/bundler_spec.rb
+++ b/spec/bundler/bundler_spec.rb
@@ -338,7 +338,7 @@ EOF
       end
 
       context "with unwritable files in a parent dir" do
-        # Regression test for https://github.com/bundler/bundler/pull/6316
+        # Regression test for https://github.com/rubygems/bundler/pull/6316
         # It doesn't matter if there are other unwritable files so long as
         # bundle_path can be created
         before do

--- a/spec/bundler/compact_index_client/updater_spec.rb
+++ b/spec/bundler/compact_index_client/updater_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Bundler::CompactIndexClient::Updater do
   subject(:updater) { described_class.new(fetcher) }
 
   context "when the ETag header is missing" do
-    # Regression test for https://github.com/bundler/bundler/issues/5463
+    # Regression test for https://github.com/rubygems/bundler/issues/5463
 
     let(:response) { double(:response, :body => "") }
 

--- a/spec/commands/binstubs_spec.rb
+++ b/spec/commands/binstubs_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe "bundle binstubs <gem>" do
   before do
-    skip "https://github.com/bundler/bundler/issues/6894" if Gem.win_platform?
+    skip "https://github.com/rubygems/bundler/issues/6894" if Gem.win_platform?
   end
 
   context "when the gem exists in the lockfile" do
@@ -278,7 +278,7 @@ RSpec.describe "bundle binstubs <gem>" do
     end
 
     it "sets correct permissions for binstubs" do
-      skip "https://github.com/bundler/bundler/issues/6895" if Gem.win_platform?
+      skip "https://github.com/rubygems/bundler/issues/6895" if Gem.win_platform?
 
       with_umask(0o002) do
         install_gemfile <<-G

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe "bundle exec" do
   end
 
   it "respects custom process title when loading through ruby" do
-    skip "https://github.com/bundler/bundler/issues/6898" if Gem.win_platform?
+    skip "https://github.com/rubygems/bundler/issues/6898" if Gem.win_platform?
 
     script_that_changes_its_own_title_and_checks_if_picked_up_by_ps_unix_utility = <<~'RUBY'
       Process.setproctitle("1-2-3-4-5-6-7-8-9-10-11-12-13-14-15")
@@ -93,7 +93,7 @@ RSpec.describe "bundle exec" do
   end
 
   it "handles --keep-file-descriptors" do
-    skip "https://github.com/bundler/bundler/issues/6898" if Gem.win_platform?
+    skip "https://github.com/rubygems/bundler/issues/6898" if Gem.win_platform?
 
     require "tempfile"
 
@@ -126,7 +126,7 @@ RSpec.describe "bundle exec" do
   end
 
   it "can run a command named --verbose" do
-    skip "https://github.com/bundler/bundler/issues/6898" if Gem.win_platform?
+    skip "https://github.com/rubygems/bundler/issues/6898" if Gem.win_platform?
 
     install_gemfile 'gem "rack"'
     File.open(bundled_app("--verbose"), "w") do |f|
@@ -286,7 +286,7 @@ RSpec.describe "bundle exec" do
   end
 
   it "does not duplicate already exec'ed RUBYOPT" do
-    skip "https://github.com/bundler/bundler/issues/6898" if Gem.win_platform?
+    skip "https://github.com/rubygems/bundler/issues/6898" if Gem.win_platform?
 
     install_gemfile <<-G
       gem "rack"
@@ -303,7 +303,7 @@ RSpec.describe "bundle exec" do
   end
 
   it "does not duplicate already exec'ed RUBYLIB" do
-    skip "https://github.com/bundler/bundler/issues/6898" if Gem.win_platform?
+    skip "https://github.com/rubygems/bundler/issues/6898" if Gem.win_platform?
 
     install_gemfile <<-G
       gem "rack"
@@ -372,7 +372,7 @@ RSpec.describe "bundle exec" do
     each_prefix.call("exec") do |exec|
       describe "when #{exec} is used" do
         before(:each) do
-          skip "https://github.com/bundler/bundler/issues/6898" if Gem.win_platform?
+          skip "https://github.com/rubygems/bundler/issues/6898" if Gem.win_platform?
 
           install_gemfile <<-G
             gem "rack"
@@ -587,7 +587,7 @@ RSpec.describe "bundle exec" do
 
   describe "with gems bundled for deployment" do
     it "works when calling bundler from another script" do
-      skip "https://github.com/bundler/bundler/issues/6898" if Gem.win_platform?
+      skip "https://github.com/rubygems/bundler/issues/6898" if Gem.win_platform?
 
       gemfile <<-G
       module Monkey
@@ -642,7 +642,7 @@ RSpec.describe "bundle exec" do
 
     shared_examples_for "it runs" do
       it "like a normally executed executable" do
-        skip "https://github.com/bundler/bundler/issues/6898" if Gem.win_platform?
+        skip "https://github.com/rubygems/bundler/issues/6898" if Gem.win_platform?
 
         subject
         expect(exitstatus).to eq(exit_code) if exitstatus
@@ -823,7 +823,7 @@ __FILE__: #{path.to_s.inspect}
         RUBY
 
         it "receives the signal" do
-          skip "https://github.com/bundler/bundler/issues/6898" if Gem.win_platform?
+          skip "https://github.com/rubygems/bundler/issues/6898" if Gem.win_platform?
 
           bundle!("exec #{path}") do |_, o, thr|
             o.gets # Consumes 'Started' and ensures that thread has started
@@ -846,7 +846,7 @@ __FILE__: #{path.to_s.inspect}
         RUBY
 
         it "makes sure no unexpected signals are restored to DEFAULT" do
-          skip "https://github.com/bundler/bundler/issues/6898" if Gem.win_platform?
+          skip "https://github.com/rubygems/bundler/issues/6898" if Gem.win_platform?
 
           test_signals.each do |n|
             Signal.trap(n, "IGNORE")
@@ -872,7 +872,7 @@ __FILE__: #{path.to_s.inspect}
       end
 
       it "correctly shells out", :ruby_repo do
-        skip "https://github.com/bundler/bundler/issues/6898" if Gem.win_platform?
+        skip "https://github.com/rubygems/bundler/issues/6898" if Gem.win_platform?
 
         file = bundled_app("file_that_bundle_execs.rb")
         create_file(file, <<-RB)
@@ -890,7 +890,7 @@ __FILE__: #{path.to_s.inspect}
       let(:expected) { ruby "gem 'openssl', '< 999999'; require 'openssl'; puts OpenSSL::VERSION", :artifice => nil }
 
       it "only leaves the default gem in the stdlib available" do
-        skip "https://github.com/bundler/bundler/issues/6898" if Gem.win_platform?
+        skip "https://github.com/rubygems/bundler/issues/6898" if Gem.win_platform?
         skip "openssl isn't a default gem" if expected.empty?
 
         install_gemfile! "" # must happen before installing the broken system gem

--- a/spec/commands/lock_spec.rb
+++ b/spec/commands/lock_spec.rb
@@ -251,7 +251,7 @@ RSpec.describe "bundle lock" do
     expect(err).to include("Removing all platforms from the bundle is not allowed")
   end
 
-  # from https://github.com/bundler/bundler/issues/4896
+  # from https://github.com/rubygems/bundler/issues/4896
   it "properly adds platforms when platform requirements come from different dependencies" do
     build_repo4 do
       build_gem "ffi", "1.9.14"

--- a/spec/commands/show_spec.rb
+++ b/spec/commands/show_spec.rb
@@ -192,7 +192,7 @@ RSpec.describe "bundle show", :bundler => "< 3" do
   end
 
   context "--outdated option" do
-    # Regression test for https://github.com/bundler/bundler/issues/5375
+    # Regression test for https://github.com/rubygems/bundler/issues/5375
     before do
       build_repo2
     end

--- a/spec/install/gemfile/gemspec_spec.rb
+++ b/spec/install/gemfile/gemspec_spec.rb
@@ -199,7 +199,7 @@ RSpec.describe "bundle install from an existing gemspec" do
 
   it "allows the gemspec to activate other gems" do
     ENV["BUNDLE_PATH__SYSTEM"] = "true"
-    # see https://github.com/bundler/bundler/issues/5409
+    # see https://github.com/rubygems/bundler/issues/5409
     #
     # issue was caused by rubygems having an unresolved gem during a require,
     # so emulate that

--- a/spec/install/gemfile/ruby_spec.rb
+++ b/spec/install/gemfile/ruby_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "ruby requirement" do
     Bundler::RubyVersion.from_string(Bundler::LockfileParser.new(File.read(bundled_app_lock)).ruby_version)
   end
 
-  # As discovered by https://github.com/bundler/bundler/issues/4147, there is
+  # As discovered by https://github.com/rubygems/bundler/issues/4147, there is
   # no test coverage to ensure that adding a gem is possible with a ruby
   # requirement. This test verifies the fix, committed in bfbad5c5.
   it "allows adding gems" do

--- a/spec/install/gemfile/sources_spec.rb
+++ b/spec/install/gemfile/sources_spec.rb
@@ -285,7 +285,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
             expect(err).not_to include("Warning: the gem 'rack' was found in multiple sources.")
             expect(the_bundle).to include_gems("depends_on_rack 1.0.1", "rack 1.0.0")
 
-            # In https://github.com/bundler/bundler/issues/3585 this failed
+            # In https://github.com/rubygems/bundler/issues/3585 this failed
             # when there is already a lock file, and the gems are missing, so try again
             system_gems []
             bundle :install
@@ -426,7 +426,7 @@ RSpec.describe "bundle install with gems on multiple sources" do
         G
       end
 
-      # Reproduction of https://github.com/bundler/bundler/issues/3298
+      # Reproduction of https://github.com/rubygems/bundler/issues/3298
       it "does not unlock the installed gem on exec" do
         expect(the_bundle).to include_gems("rack 0.9.1")
       end

--- a/spec/realworld/edgecases_spec.rb
+++ b/spec/realworld/edgecases_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe "real world edgecases", :realworld => true, :sometimes => true do
   end
 
   it "is able to update a top-level dependency when there is a conflict on a shared transitive child" do
-    # from https://github.com/bundler/bundler/issues/5031
+    # from https://github.com/rubygems/bundler/issues/5031
 
     gemfile <<-G
       source "https://rubygems.org"
@@ -194,7 +194,7 @@ RSpec.describe "real world edgecases", :realworld => true, :sometimes => true do
     expect(lockfile).to include(rubygems_version("paperclip", "~> 5.1.0"))
   end
 
-  # https://github.com/bundler/bundler/issues/1500
+  # https://github.com/rubygems/bundler/issues/1500
   it "does not fail install because of gem plugins" do
     realworld_system_gems("open_gem --version 1.4.2", "rake --version 0.9.2")
     gemfile <<-G


### PR DESCRIPTION
Related: #7572.

### What was the end-user problem that led to this PR?

A lot of things use the outdated `https://github.com/bundler/bundler` URL (and similarly for e.g. `bundler/bundler-site`).

### What is your fix for the problem, implemented in this PR?

My fix was to update the outdated URLs. :slightly_smiling_face: 

### TODO

- [x] `bundler.gemspec`
- [x] `CHANGELOG.md` (Moved to its own PR, #7582)
- [x] `CODE_OF_CONDUCT.md`
- [x] `doc/`, excluding reference to now-dead `pullreview.com`
- [x] `doc/contributing/HOW_YOU_CAN_HELP.md` reference to long-dead `pullreview.com`
- [x] `.github/config.yml`
- [x] `lib/` (comments)
- [ ] `lib/` (functional changes)
- [ ] `man/`
- [x] `README.md`
- [x] `spec/` (comments, `skip` messages)
- [ ] `spec/` (functional changes)
- [ ] `task/release.rake`