### PR TITLE
Don't ignore resolved platform information

### DIFF
--- a/lib/bundler/lazy_specification.rb
+++ b/lib/bundler/lazy_specification.rb
@@ -80,8 +80,13 @@ module Bundler
       @specification = if source.is_a?(Source::Gemspec) && source.gemspec.name == name
         source.gemspec.tap {|s| s.source = source }
       else
-        search = source.specs.search(search_object).last
-        if search && Gem::Platform.new(search.platform) != Gem::Platform.new(platform) && !search.runtime_dependencies.-(dependencies.reject {|d| d.type == :development }).empty?
+        platform_object = Gem::Platform.new(platform)
+        candidates = source.specs.search(search_object)
+        same_platform_candidates = candidates.select do |spec|
+          MatchPlatform.platforms_match?(spec.platform, platform_object)
+        end
+        search = same_platform_candidates.last || candidates.last
+        if search && Gem::Platform.new(search.platform) != platform_object && !search.runtime_dependencies.-(dependencies.reject {|d| d.type == :development }).empty?
           Bundler.ui.warn "Unable to use the platform-specific (#{search.platform}) version of #{name} (#{version}) " \
             "because it has different dependencies from the #{platform} version. " \
             "To use the platform-specific version of the gem, run `bundle config set specific_platform true` and install again."

--- a/lib/bundler/match_platform.rb
+++ b/lib/bundler/match_platform.rb
@@ -15,7 +15,10 @@ module Bundler
       return true if Gem::Platform::RUBY == gemspec_platform
       return true if local_platform == gemspec_platform
       gemspec_platform = Gem::Platform.new(gemspec_platform)
-      return true if GemHelpers.generic(gemspec_platform) === local_platform
+      generic_gemspec_platform = GemHelpers.generic(gemspec_platform)
+      unless generic_gemspec_platform == Gem::Platform::RUBY
+        return true if generic_gemspec_platform === local_platform
+      end
       return true if gemspec_platform === local_platform
 
       false

--- a/lib/bundler/match_platform.rb
+++ b/lib/bundler/match_platform.rb
@@ -15,10 +15,7 @@ module Bundler
       return true if Gem::Platform::RUBY == gemspec_platform
       return true if local_platform == gemspec_platform
       gemspec_platform = Gem::Platform.new(gemspec_platform)
-      generic_gemspec_platform = GemHelpers.generic(gemspec_platform)
-      unless generic_gemspec_platform == Gem::Platform::RUBY
-        return true if generic_gemspec_platform === local_platform
-      end
+      return true if GemHelpers.generic(gemspec_platform) === local_platform
       return true if gemspec_platform === local_platform
 
       false

--- a/spec/install/gems/resolving_spec.rb
+++ b/spec/install/gems/resolving_spec.rb
@@ -143,6 +143,29 @@ RSpec.describe "bundle install with install-time dependencies" do
         expect(out).to_not include("rack-9001.0.0 requires ruby version > 9000")
         expect(the_bundle).to include_gems("rack 1.2")
       end
+
+      it "installs the older not platform specific version" do
+        build_repo4 do
+          build_gem "rack", "9001.0.0" do |s|
+            s.required_ruby_version = "> 9000"
+          end
+          build_gem "rack", "1.2" do |s|
+            s.platform = Bundler.local_platform
+            s.required_ruby_version = "> 9000"
+          end
+          build_gem "rack", "1.2"
+        end
+
+        install_gemfile <<-G, :artifice => "compact_index_rate_limited", :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }
+          ruby "#{RUBY_VERSION}"
+          source "http://localgemserver.test/"
+          gem 'rack'
+        G
+
+        expect(out).to_not include("rack-9001.0.0 requires ruby version > 9000")
+        expect(out).to_not include("rack-1.2-#{Bundler.local_platform} requires ruby version > 9000")
+        expect(the_bundle).to include_gems("rack 1.2")
+      end
     end
 
     context "allows no gems" do

--- a/spec/install/gems/resolving_spec.rb
+++ b/spec/install/gems/resolving_spec.rb
@@ -150,17 +150,19 @@ RSpec.describe "bundle install with install-time dependencies" do
             s.required_ruby_version = "> 9000"
           end
           build_gem "rack", "1.2" do |s|
-            s.platform = Bundler.local_platform
+            s.platform = mingw
             s.required_ruby_version = "> 9000"
           end
           build_gem "rack", "1.2"
         end
 
-        install_gemfile <<-G, :artifice => "compact_index_rate_limited", :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }
-          ruby "#{RUBY_VERSION}"
-          source "http://localgemserver.test/"
-          gem 'rack'
-        G
+        simulate_platform mingw do
+          install_gemfile <<-G, :artifice => "compact_index_rate_limited", :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }
+            ruby "#{RUBY_VERSION}"
+            source "http://localgemserver.test/"
+            gem 'rack'
+          G
+        end
 
         expect(out).to_not include("rack-9001.0.0 requires ruby version > 9000")
         expect(out).to_not include("rack-1.2-#{Bundler.local_platform} requires ruby version > 9000")

--- a/spec/install/gems/resolving_spec.rb
+++ b/spec/install/gems/resolving_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe "bundle install with install-time dependencies" do
         end
 
         simulate_platform mingw do
-          install_gemfile <<-G, :artifice => "compact_index_rate_limited", :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }
+          install_gemfile <<-G, :artifice => "compact_index", :env => { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }
             ruby "#{RUBY_VERSION}"
             source "http://localgemserver.test/"
             gem 'rack'


### PR DESCRIPTION
This is a follow-up change of #7522.

### What was the end-user problem that led to this PR?

The problem was installing wrong platform gem even when resolver resolves the correct platform gem.

See also:

  * https://github.com/rubygems/bundler/pull/7522#issuecomment-574628275
  * https://github.com/rubygems/bundler/pull/7522#issuecomment-574882536

### What was your diagnosis of the problem?

My diagnosis was `Bundler::LazySpecification#__materialize__` doesn't care about the resolved platform information.

### What is your fix for the problem, implemented in this PR?

My fix cares about the resolved platform information.

### Why did you choose this fix out of the possible options?

I chose this fix because we should respect the resolved platform information to install correct gem.