### PR TITLE
Fix flaky test failure

### DIFF
--- a/spec/runtime/gem_tasks_spec.rb
+++ b/spec/runtime/gem_tasks_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe "require 'bundler/gem_tasks'" do
   context "rake build when path has spaces" do
     before do
       spaced_bundled_app = tmp.join("bundled app")
-      FileUtils.mv bundled_app, spaced_bundled_app
+      FileUtils.cp_r bundled_app, spaced_bundled_app
       bundle! "exec rake build", :dir => spaced_bundled_app
     end
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that sometimes a spec is failing on Windows because the rename syscall sometimes is raising Errno::EXDEV.

### What was your diagnosis of the problem?

I don't really know why this problem is happening.

### What is your fix for the problem, implemented in this PR?

My fix is to stop renaming the folder and copy it instead.

### Why did you choose this fix out of the possible options?

I chose this fix because copying will no longer make a rename syscall, so at least it should no longer fail in the same way.