### PR TITLE
Add support for BUNDLER_ prefixed debug environment variables

### DIFF
--- a/lib/bundler/gem_version_promoter.rb
+++ b/lib/bundler/gem_version_promoter.rb
@@ -7,7 +7,7 @@ module Bundler
   # available dependency versions as found in its index, before returning it to
   # to the resolution engine to select the best version.
   class GemVersionPromoter
-    DEBUG = ENV["DEBUG_RESOLVER"]
+    DEBUG = ENV["BUNDLER_DEBUG_RESOLVER"] || ENV["DEBUG_RESOLVER"]
 
     attr_reader :level, :locked_specs, :unlock_gems
 

--- a/lib/bundler/resolver.rb
+++ b/lib/bundler/resolver.rb
@@ -80,7 +80,12 @@ module Bundler
 
     def debug?
       return @debug_mode if defined?(@debug_mode)
-      @debug_mode = ENV["DEBUG_RESOLVER"] || ENV["DEBUG_RESOLVER_TREE"] || false
+      @debug_mode =
+        ENV["BUNDLER_DEBUG_RESOLVER"] ||
+        ENV["BUNDLER_DEBUG_RESOLVER_TREE"] ||
+        ENV["DEBUG_RESOLVER"] ||
+        ENV["DEBUG_RESOLVER_TREE"] ||
+        false
     end
 
     def before_resolution

--- a/spec/install/gems/resolving_spec.rb
+++ b/spec/install/gems/resolving_spec.rb
@@ -69,6 +69,20 @@ RSpec.describe "bundle install with install-time dependencies" do
       expect(the_bundle).to include_gems "net_a 1.0", "net_b 1.0", "net_c 1.0", "net_d 1.0", "net_e 1.0"
     end
 
+    context "with ENV['BUNDLER_DEBUG_RESOLVER'] set" do
+      it "produces debug output" do
+        gemfile <<-G
+          source "#{file_uri_for(gem_repo1)}"
+          gem "net_c"
+          gem "net_e"
+        G
+
+        bundle :install, :env => { "BUNDLER_DEBUG_RESOLVER" => "1" }
+
+        expect(err).to include("Creating possibility state for net_c")
+      end
+    end
+
     context "with ENV['DEBUG_RESOLVER'] set" do
       it "produces debug output" do
         gemfile <<-G


### PR DESCRIPTION
DEBUG_RESOLVER is used in RubyGems too. So we can't enable it only for
Bundler.

### What was the end-user problem that led to this PR?

The problem was not the end-user problem. It's a developer problem.

### What was your diagnosis of the problem?

My diagnosis was RubyGems also uses `DEBUG_RESOLVER` environment variable. So we can't use `DEBUG_RESOLVER` environment variable to enable debug mode only for Bundler. We can use `DEBUG_RESOLVER_TREE` instead of `DEBUG_RESOLVER` only for `Bundler::Resolver`. But we can't do it for `Bundler::GemVersionPromoter`.

### What is your fix for the problem, implemented in this PR?

My fix adds `BUNDLER_` prefix to `DEBUG_RESOLVER` and `DEBUG_RESOLVER_TREE` like other environment variables for Bundler such as `BUNDLER_EDITOR` do.

### Why did you choose this fix out of the possible options?

I chose this fix because adding prefix is a common way. Bundlerd Molinillo and Thor also use this way such as `MOLINILLO_DEBUG` and `THOR_SHELL`.
