### PR TITLE
Prepend debug label to resolver's debug message

### DIFF
--- a/lib/bundler/resolver.rb
+++ b/lib/bundler/resolver.rb
@@ -75,7 +75,7 @@ module Bundler
       return unless debug?
       debug_info = yield
       debug_info = debug_info.inspect unless debug_info.is_a?(String)
-      warn debug_info.split("\n").map {|s| "  " * depth + s }
+      warn debug_info.split("\n").map {|s| "BUNDLER: " + "  " * depth + s }
     end
 
     def debug?

--- a/spec/install/gems/resolving_spec.rb
+++ b/spec/install/gems/resolving_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe "bundle install with install-time dependencies" do
 
         bundle :install, :env => { "BUNDLER_DEBUG_RESOLVER" => "1" }
 
-        expect(err).to include("Creating possibility state for net_c")
+        expect(err).to include("BUNDLER: Starting resolution")
       end
     end
 
@@ -93,7 +93,7 @@ RSpec.describe "bundle install with install-time dependencies" do
 
         bundle :install, :env => { "DEBUG_RESOLVER" => "1" }
 
-        expect(err).to include("Creating possibility state for net_c")
+        expect(err).to include("BUNDLER: Starting resolution")
       end
     end
 
@@ -108,8 +108,8 @@ RSpec.describe "bundle install with install-time dependencies" do
         bundle :install, :env => { "DEBUG_RESOLVER_TREE" => "1" }
 
         expect(err).to include(" net_b").
-          and include("Starting resolution").
-          and include("Finished resolution").
+          and include("BUNDLER: Starting resolution").
+          and include("BUNDLER: Finished resolution").
           and include("Attempting to activate")
       end
     end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was not a end-user problem. This was a developer problem.

If we have many debug messages (for example, I added many `pp [...]` to debug #7522), it's difficult to find resolver's debug messages.

### What was your diagnosis of the problem?

My diagnosis was no common keywords in resolver's debug message is a problem. If we have a common keyword, we can find resolver's debug messages from many debug messages easily.

### What is your fix for the problem, implemented in this PR?

My fix prepends `BUNDLER: ` to all resolver's debug messages. If we have the same label in all resolver's debug messages, we can find resolver's debug message easily. For example, we can use "/BUNDLER:" in less.

### Why did you choose this fix out of the possible options?

I chose this fix because `BUNDLER: ` will not conflict. Other candidate is `DEBUG: ` but it may be used by other library. If the keyword conflicts, it's not easy to find resolver's debug messages. `Bundler::Resolver: ` will be more safer but it may be long.
