### PR TITLE
Fix flaky spec failure

### DIFF
--- a/spec/bundler/friendly_errors_spec.rb
+++ b/spec/bundler/friendly_errors_spec.rb
@@ -7,13 +7,13 @@ require "cgi"
 RSpec.describe Bundler, "friendly errors" do
   context "with invalid YAML in .gemrc" do
     before do
-      File.open(Gem.configuration.config_file_name, "w") do |f|
+      File.open(home(".gemrc"), "w") do |f|
         f.write "invalid: yaml: hah"
       end
     end
 
     after do
-      FileUtils.rm(Gem.configuration.config_file_name)
+      FileUtils.rm(home(".gemrc"))
     end
 
     it "reports a relevant friendly error message" do


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

If you're updating documentation, make sure you run `bin/rake man:build` and
squash the result into your changes, so that all documentation formats are
updated.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

### What was the end-user or developer problem that led to this PR?

The problem was flaky tests: https://www.travis-ci.org/rubygems/bundler/jobs/639403049.

### What is your fix for the problem, implemented in this PR?

My diagnosis was that if our test code happens to run `Gem.configuration` before `ENV["HOME"]` is changed for our tests, this test starts failing because the test first writes to the global `~/.gemrc` file (not in `tmp/`), because `Gem.config_file` has that value memoized. Then, however, the `bundle install` subprocess infers `Gem.config_file` from the modified `ENV["HOME"]` and tries to read `tmp/home/.gemrc`. However, that file doesn't exist, so rubygems configuration is ignored and doesn't print an error like the test expects.
    
My fix is to make this test independent from the specific rubygems configuration in the main test process.

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->
