### PR TITLE
Don't call Warn on LoadError

### DIFF
--- a/lib/bundler/friendly_errors.rb
+++ b/lib/bundler/friendly_errors.rb
@@ -24,11 +24,6 @@ module Bundler
       when LoadError
         raise error unless error.message =~ /cannot load such file -- openssl|openssl.so|libcrypto.so/
         Bundler.ui.error "\nCould not load OpenSSL. #{error.class}: #{error}\n#{error.backtrace.join("\n  ")}"
-        Bundler.ui.warn <<-WARN, :wrap => true
-          You must recompile Ruby with OpenSSL support or change the sources in your \
-          Gemfile from 'https' to 'http'. Instructions for compiling with OpenSSL \
-          using RVM are available at https://rvm.io/packages/openssl.
-        WARN
       when Interrupt
         Bundler.ui.error "\nQuitting..."
         Bundler.ui.trace error

--- a/spec/bundler/friendly_errors_spec.rb
+++ b/spec/bundler/friendly_errors_spec.rb
@@ -123,11 +123,6 @@ RSpec.describe Bundler, "friendly errors" do
         expect(Bundler.ui).to receive(:error).with("\nCould not load OpenSSL. LoadError: cannot load such file -- openssl\nbacktrace")
         Bundler::FriendlyErrors.log_error(error)
       end
-
-      it "Bundler.ui receive warn" do
-        expect(Bundler.ui).to receive(:warn).with(any_args, :wrap => true)
-        Bundler::FriendlyErrors.log_error(error)
-      end
     end
 
     context "Interrupt" do


### PR DESCRIPTION
Related to #7192 and #7527. When trying to run bundler without OpenSSL, the resulting warning recommends recompiling Ruby, changing the Gemfile sources to http, and then gives an RVM-specific link that won't be helpful for everyone.

I think the error message is now specific enough to stand on its own and help people debug, so we should remove the warning entirely. (Open to other opinions, though.)