### PR TITLE
Improve cache specs

### DIFF
--- a/spec/cache/path_spec.rb
+++ b/spec/cache/path_spec.rb
@@ -26,7 +26,6 @@ RSpec.describe "bundle cache with path" do
     expect(bundled_app("vendor/cache/foo-1.0")).to exist
     expect(bundled_app("vendor/cache/foo-1.0/.bundlecache")).to be_file
 
-    FileUtils.rm_rf lib_path("foo-1.0")
     expect(the_bundle).to include_gems "foo 1.0"
   end
 
@@ -45,7 +44,6 @@ RSpec.describe "bundle cache with path" do
     expect(bundled_app("vendor/cache/#{libname}")).to exist
     expect(bundled_app("vendor/cache/#{libname}/.bundlecache")).to be_file
 
-    FileUtils.rm_rf libpath
     expect(the_bundle).to include_gems "#{libname} 1.0"
   end
 
@@ -66,7 +64,6 @@ RSpec.describe "bundle cache with path" do
     bundle :cache
 
     expect(bundled_app("vendor/cache/foo-1.0")).to exist
-    FileUtils.rm_rf lib_path("foo-1.0")
 
     run "require 'foo'"
     expect(out).to eq("CACHE")

--- a/spec/cache/path_spec.rb
+++ b/spec/cache/path_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe "bundle cache with path" do
   end
 
   it "copies when the path is outside the bundle and the paths intersect" do
-    libname = File.basename(Dir.pwd) + "_gem"
-    libpath = File.join(File.dirname(Dir.pwd), libname)
+    libname = File.basename(bundled_app) + "_gem"
+    libpath = File.join(File.dirname(bundled_app), libname)
 
     build_lib libname, :path => libpath
 


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

If you're updating documentation, make sure you run `bin/rake man:build` and
squash the result into your changes, so that all documentation formats are
updated.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

### What was the end-user or developer problem that led to this PR?

I noticed that when running specs on Windows, sometime I got a `_gem` leftover folder in the root of the repo.

### What is your fix for the problem, implemented in this PR?

My fix is to run the particular spec creating this test folder in `tmp`, just like the rest of the specs.