### PR TITLE
Fix failing spec when run directly

### DIFF
--- a/spec/bundler/gem_helper_spec.rb
+++ b/spec/bundler/gem_helper_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Bundler::GemHelper do
   before(:each) do
     global_config "BUNDLE_GEM__MIT" => "false", "BUNDLE_GEM__TEST" => "false", "BUNDLE_GEM__COC" => "false", "BUNDLE_GEM__RUBOCOP" => "false"
     bundle "gem #{app_name}"
-    prepare_gemspec(app_gemspec_path)
+    @app_gemspec_content = prepare_gemspec(app_gemspec_path)
   end
 
   context "determining gemspec" do
@@ -64,10 +64,9 @@ RSpec.describe Bundler::GemHelper do
     let(:app_version) { "0.1.0" }
     let(:app_gem_dir) { app_path.join("pkg") }
     let(:app_gem_path) { app_gem_dir.join("#{app_name}-#{app_version}.gem") }
-    let(:app_gemspec_content) { File.read(app_gemspec_path) }
 
     before(:each) do
-      content = app_gemspec_content.gsub("TODO: ", "")
+      content = @app_gemspec_content.gsub("TODO: ", "")
       content.sub!(/homepage\s+= ".*"/, 'homepage = ""')
       content.gsub!(/spec\.metadata.+\n/, "")
       File.open(app_gemspec_path, "w") {|file| file << content }
@@ -126,7 +125,7 @@ RSpec.describe Bundler::GemHelper do
       context "when build failed" do
         it "raises an error with appropriate message" do
           # break the gemspec by adding back the TODOs
-          File.open(app_gemspec_path, "w") {|file| file << app_gemspec_content }
+          File.open(app_gemspec_path, "w") {|file| file << @app_gemspec_content }
           expect { subject.build_gem }.to raise_error(/TODO/)
         end
       end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -532,10 +532,12 @@ module Spec
     end
 
     def process_file(pathname)
-      changed_lines = pathname.readlines.map do |line|
+      previous_content = pathname.readlines
+      changed_lines = previous_content.map do |line|
         yield line
       end
       File.open(pathname, "w") {|file| file.puts(changed_lines.join) }
+      previous_content.join
     end
 
     def with_env_vars(env_hash, &block)


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

If you're updating documentation, make sure you run `bin/rake man:build` and
squash the result into your changes, so that all documentation formats are
updated.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

### What was the end-user or developer problem that led to this PR?

`bin/rspec ./spec/bundler/gem_helper_spec.rb:127` fails. I have no idea why current specs are passing since it doesn't seem order dependent to me :man_shrugging:

The error is:

 
```

  1) Bundler::GemHelper gem management #build_gem when build failed raises an error with appropriate message
     Failure/Error: expect { subject.build_gem }.to raise_error(/TODO/)

       expected /TODO/ but nothing was raised

       Commands:
       $  /home/deivid/.rbenv/versions/2.7.0/bin/ruby -I/home/deivid/Code/bundler/lib:/home/deivid/Code/bundler/spec -rsupport/hax -rsupport/artifice/fail /home/deivid/Code/bundler/exe/bundle gem lorem__ipsum
       Creating gem 'lorem__ipsum'...
             create  lorem__ipsum/Gemfile
             create  lorem__ipsum/lib/lorem__ipsum.rb
             create  lorem__ipsum/lib/lorem__ipsum/version.rb
             create  lorem__ipsum/lorem__ipsum.gemspec
             create  lorem__ipsum/Rakefile
             create  lorem__ipsum/README.md
             create  lorem__ipsum/bin/console
             create  lorem__ipsum/bin/setup
             create  lorem__ipsum/.gitignore
       Initializing git repo in /home/deivid/Code/bundler/tmp/2/bundled_app/lorem__ipsum
       Gem 'lorem__ipsum' was successfully created. For more information on making a RubyGem visit https://bundler.io/guides/creating_gem.html
       # $? => 0
     # ./spec/bundler/gem_helper_spec.rb:130:in `block (5 levels) in <top (required)>'
     # ./spec/spec_helper.rb:109:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:109:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:76:in `block (2 levels) in <top (required)>'
     # ./spec/support/rubygems_ext.rb:98:in `load'
     # ./spec/support/rubygems_ext.rb:98:in `gem_load_and_activate'
     # ./spec/support/rubygems_ext.rb:45:in `gem_load'

Finished in 10.75 seconds (files took 0.75658 seconds to load)
23 examples, 1 failure

Failed examples:

rspec ./spec/bundler/gem_helper_spec.rb:127 # Bundler::GemHelper gem management #build_gem when build failed raises an error with appropriate message

```

### What is your fix for the problem, implemented in this PR?

The idea of this spec is to check that `bundle gem` raises when it has TODO. So it tries to undo what its before callback does (replace the TODOs, because they're not useful for the rest of the specs), and check that an error is raised.

However, the content it's replacing the gemspec file with already has the TODOs removed, since that's what the `prepare_gemspec` helper does in the outtermost before callback of this file.

The solution is to make the `prepare_gemspec` method return the original content, and replace the gemspec with that.