### PR TITLE
Simplify arguments to `sh`

### DIFF
--- a/lib/bundler/gem_helper.rb
+++ b/lib/bundler/gem_helper.rb
@@ -73,7 +73,7 @@ module Bundler
 
     def build_gem
       file_name = nil
-      sh("#{gem_command} build -V #{spec_path.shellescape}".shellsplit) do
+      sh([*gem_command, "build", "-V", spec_path]) do
         file_name = File.basename(built_gem_path)
         SharedHelpers.filesystem_access(File.join(base, "pkg")) {|p| FileUtils.mkdir_p(p) }
         FileUtils.mv(built_gem_path, "pkg")
@@ -84,9 +84,9 @@ module Bundler
 
     def install_gem(built_gem_path = nil, local = false)
       built_gem_path ||= build_gem
-      cmd = "#{gem_command} install #{built_gem_path}"
-      cmd += " --local" if local
-      _, status = sh_with_status(cmd.shellsplit)
+      cmd = [*gem_command, "install", built_gem_path.to_s]
+      cmd << "--local" if local
+      _, status = sh_with_status(cmd)
       unless status.success?
         raise "Couldn't install gem, run `gem install #{built_gem_path}' for more detailed output"
       end
@@ -96,7 +96,7 @@ module Bundler
   protected
 
     def rubygem_push(path)
-      cmd = %W[#{gem_command} push #{path}]
+      cmd = [*gem_command, "push", path]
       cmd << "--key" << gem_key if gem_key
       cmd << "--host" << allowed_push_host if allowed_push_host
       unless allowed_push_host || Bundler.user_home.join(".gem/credentials").file?
@@ -210,7 +210,7 @@ module Bundler
     end
 
     def gem_command
-      ENV["GEM_COMMAND"] ? ENV["GEM_COMMAND"] : "gem"
+      ENV["GEM_COMMAND"]&.shellsplit || ["gem"]
     end
   end
 end

--- a/spec/bundler/gem_helper_spec.rb
+++ b/spec/bundler/gem_helper_spec.rb
@@ -231,7 +231,8 @@ RSpec.describe Bundler::GemHelper do
           end
 
           it "uses Kernel.system" do
-            expect(Kernel).to receive(:system).with(gem_bin, "push", app_gem_path.to_s, "--host", "http://example.org").and_return(true)
+            cmd = gem_bin.shellsplit
+            expect(Kernel).to receive(:system).with(*cmd, "push", app_gem_path.to_s, "--host", "http://example.org").and_return(true)
 
             Rake.application["release"].invoke
           end


### PR DESCRIPTION
Get rid of escaping and splitting shell code repeatedly.

### What was the end-user or developer problem that led to this PR?

No changes for the end-users.

### What is your fix for the problem, implemented in this PR?

As `built_gem_path` in `install_gems` is not escaped, this may fix a trouble in the case the argument have shell special characters.
