### PR TITLE
Workaround jruby issue

### DIFF
--- a/.github/workflows/jruby.yml
+++ b/.github/workflows/jruby.yml
@@ -1,0 +1,31 @@
+name: jruby
+
+on:
+  pull_request:
+
+  push:
+    branches:
+      - staging
+      - trying
+
+jobs:
+  warbler:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Setup ruby
+        uses: eregon/use-ruby-action@v1
+        with:
+          ruby-version: jruby-9.2.9.0
+
+      - name: Install local bundler
+        run: bin/rake install:local
+
+      - name: Run a warbler project
+        run: |
+          cd spec/realworld/fixtures/warbler
+          bundle install
+          bundle exec warble
+          java -jar warbler.jar

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -408,6 +408,8 @@ Naming/ConstantName:
 
 Naming/FileName:
   Enabled: true
+  Exclude:
+    - 'spec/realworld/fixtures/warbler/bin/warbler-example.rb'
 
 Naming/HeredocDelimiterCase:
   Enabled: true

--- a/lib/bundler/source/path.rb
+++ b/lib/bundler/source/path.rb
@@ -132,7 +132,11 @@ module Bundler
       end
 
       def expand(somepath)
-        somepath.expand_path(root_path)
+        if Bundler.current_ruby.jruby? # TODO: Unify when https://github.com/rubygems/bundler/issues/7598 fixed upstream and all supported jrubies include the fix
+          somepath.expand_path(root_path).expand_path
+        else
+          somepath.expand_path(root_path)
+        end
       rescue ArgumentError => e
         Bundler.ui.debug(e)
         raise PathError, "There was an error while trying to use the path " \

--- a/spec/realworld/fixtures/warbler/.gitignore
+++ b/spec/realworld/fixtures/warbler/.gitignore
@@ -1,0 +1,2 @@
+*.jar
+Gemfile.lock

--- a/spec/realworld/fixtures/warbler/Gemfile
+++ b/spec/realworld/fixtures/warbler/Gemfile
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "demo", :path => "./demo"
+gem "jruby-jars", "~> 9.2"
+gem "warbler", "~> 2.0"

--- a/spec/realworld/fixtures/warbler/bin/warbler-example.rb
+++ b/spec/realworld/fixtures/warbler/bin/warbler-example.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+puts require "bundler/setup"

--- a/spec/realworld/fixtures/warbler/demo/demo.gemspec
+++ b/spec/realworld/fixtures/warbler/demo/demo.gemspec
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+Gem::Specification.new do |spec|
+  spec.name = "demo"
+  spec.version = "1.0"
+  spec.author = "Somebody"
+  spec.summary = "A demo gem"
+  spec.license = "MIT"
+  spec.homepage = "https://example.org"
+end


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

If you're updating documentation, make sure you run `bin/rake man:build` and
squash the result into your changes, so that all documentation formats are
updated.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

### What was the end-user or developer problem that led to this PR?

The problem is that if a Gemfile contains `:path` gem with a relative path, the bundler environment no longer works when the app is packaged as a `jar` with [warbler](https://github.com/jruby/warbler).

### What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

Issue was introduced https://github.com/rubygems/bundler/commit/c7532ced89bbc8ddc7296c56391c1c3cc981c54a, since when `jruby` deals with urls of the form "uri:classloader", it has a weird inconsistency where `Pathname#expand_path` with an argument always returns `uri:classloader://` (double slash) as the canonical version of the path, while `Pathname#expand_path` without an argument always returns `uri:classloader/` (single slash) as the canonical version of it.

```
Pathname.new("uri:classloader://foo/bar").expand_path
#  => <Pathname:uri:classloader:/foo/bar>

Pathname.new("uri:classloader:/foo/bar").expand_path
# => <Pathname:uri:classloader:/foo/bar>

Pathname.new("foo/bar").expand_path("uri:classloader://")
# => <Pathname:uri:classloader://foo/bar>

Pathname.new("foo/bar").expand_path("uri:classloader:/")
# => <Pathname:uri:classloader://foo/bar>
```

That makes `Pathname#relative_path_from` (introduced with the offending commit) explode because we end up passing to different "uri:classloader" kind of paths to it.

I believe this should be fixed in `jruby` be doing either or both of the following things:

* Make `Pathname#expand_path` return consistent versions of "uri:classpath" paths.
* Make `Pathname#relative_path_from` support different versions of "uri:classpath" paths, since they are both absolute paths after all.

But I'm workarounding the issue in `bundler` by adding an extra `expand_path` call at an appropriate place to make sure that the URLs we pass to `Pathname#relative_path_from` have a consistent shape.

Fixes #7598.

NOTE: We currently don't have the ability to run a full test suite for every PR on jruby because it's too slow (#4796 attempted to improve that but it was never completed), and it doesn't even fully pass (#7603). As an alternative, I'm adding some realworld bare tests to be run under jruby, just to make sure common tasks like this one work.