### PR TITLE
Fix config location edge case

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -285,7 +285,13 @@ module Bundler
 
     def app_config_path
       if app_config = ENV["BUNDLE_APP_CONFIG"]
-        Pathname.new(app_config).expand_path(root)
+        app_config_pathname = Pathname.new(app_config)
+
+        if app_config_pathname.absolute?
+          app_config_pathname
+        else
+          app_config_pathname.expand_path(root)
+        end
       else
         root.join(".bundle")
       end

--- a/spec/commands/config_spec.rb
+++ b/spec/commands/config_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe ".bundle/config" do
     end
   end
 
-  describe "location" do
+  describe "location with a gemfile" do
     before :each do
       gemfile <<-G
         source "#{file_uri_for(gem_repo1)}"
@@ -61,6 +61,16 @@ RSpec.describe ".bundle/config" do
       expect(bundled_app(".bundle")).not_to exist
       expect(bundled_app("../foo/config")).to exist
       expect(the_bundle).to include_gems "rack 1.0.0", :dir => bundled_app("omg")
+    end
+  end
+
+  describe "location without a gemfile" do
+    it "works with an absolute path" do
+      ENV["BUNDLE_APP_CONFIG"] = tmp("foo/bar").to_s
+      bundle "config set --local path vendor/bundle"
+
+      expect(bundled_app(".bundle")).not_to exist
+      expect(tmp("foo/bar/config")).to exist
     end
   end
 


### PR DESCRIPTION


<!--
Thanks so much for the contribution!

If you're updating documentation, make sure you run `bin/rake man:build` and
squash the result into your changes, so that all documentation formats are
updated.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

### What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

The problem was that if `BUNDLE_APP_CONFIG` is set to an absolute path, and there's no Gemfile up in the directory hierarchy, bundler would end up using the default config location instead of the customized one.


### What is your fix for the problem, implemented in this PR?

My fix is to completely avoid bundler's root resolution for resolving the config path in this case, since `BUNDLE_APP_CONFIG` includes all the information we need to know.

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

Fixes #7610.