### PR TITLE
Adhere to gemfile name preference also for project skeleton.

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -457,6 +457,10 @@ EOF
       Bundler.settings[:system_bindir] || Bundler.rubygems.gem_bindir
     end
 
+    def preferred_gemfile_name
+      Bundler.settings[:init_gems_rb] ? "gems.rb" : "Gemfile"
+    end
+
     def use_system_gems?
       configured_bundle_path.use_system_gems?
     end

--- a/lib/bundler/cli/gem.rb
+++ b/lib/bundler/cli/gem.rb
@@ -63,7 +63,7 @@ module Bundler
       ensure_safe_gem_name(name, constant_array)
 
       templates = {
-        "Gemfile.tt" => "Gemfile",
+        "#{Bundler.preferred_gemfile_name}.tt" => Bundler.preferred_gemfile_name,
         "lib/newgem.rb.tt" => "lib/#{namespaced_path}.rb",
         "lib/newgem/version.rb.tt" => "lib/#{namespaced_path}/version.rb",
         "newgem.gemspec.tt" => "#{name}.gemspec",

--- a/lib/bundler/cli/init.rb
+++ b/lib/bundler/cli/init.rb
@@ -41,7 +41,7 @@ module Bundler
   private
 
     def gemfile
-      @gemfile ||= Bundler.settings[:init_gems_rb] ? "gems.rb" : "Gemfile"
+      @gemfile ||= Bundler.preferred_gemfile_name
     end
   end
 end


### PR DESCRIPTION
Fixes #7626.

Resolving gemfile name preference - original `Gemfile` or newer `gems.rb` moved to Bundler's singleton as being shared by multiple classes, ie. because of DRY principle.
