### PR TITLE
Use `bundle config` instead of a deprecated flag in an error message.

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -518,7 +518,8 @@ EOF
         Your user account isn't allowed to install to the system RubyGems.
         You can cancel this installation and run:
 
-            bundle install --path vendor/bundle
+            bundle config set --local path 'vendor/bundle'
+            bundle install
 
         to install the gems into ./vendor/bundle/, or you can enter your password
         and install the bundled gems to RubyGems using sudo.


### PR DESCRIPTION
### What was the end-user or developer problem that led to this PR?

When trying to install gems to the system RubyGems and it fails, bundler shows a message as follows:

```
$ bundle install
# snip
Your user account isn't allowed to install to the system RubyGems.
  You can cancel this installation and run:

      bundle install --path vendor/bundle

  to install the gems into ./vendor/bundle/, or you can enter your password
  and install the bundled gems to RubyGems using sudo.
```

But the `--path` flag is deprecated, `bundle install --path vendor/bundle` shows:

```
$ bundle install --path vendor/bundle
[DEPRECATED] The `--path` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set path 'vendor/bundle'`, and stop using this flag
# snip
```

### What is your fix for the problem, implemented in this PR?

This PR changes the message to show `bundle config set --local path` instead of the deprecated `--path` flag.