### PR TITLE
Unfreeze dependency hashes

### DIFF
--- a/spec/support/rubygems_ext.rb
+++ b/spec/support/rubygems_ext.rb
@@ -4,7 +4,7 @@ require_relative "path"
 
 module Spec
   module Rubygems
-    DEV_DEPS = {
+    DEV_DEPS = { # rubocop:disable Style/MutableConstant
       "automatiek" => "~> 0.3.0",
       "parallel_tests" => "~> 2.29",
       "rake" => "~> 12.0",
@@ -12,9 +12,9 @@ module Spec
       "rspec" => "~> 3.8",
       "rubocop" => "= 0.77.0",
       "rubocop-performance" => "= 1.5.1",
-    }.freeze
+    }
 
-    DEPS = {
+    DEPS = { # rubocop:disable Style/MutableConstant
       "rack" => "2.0.8",
       "rack-test" => "~> 1.1",
       "artifice" => "~> 0.6.0",
@@ -25,7 +25,7 @@ module Spec
       "builder" => "~> 3.2",
       # ruby-graphviz is used by the viz tests
       "ruby-graphviz" => ">= 0.a",
-    }.freeze
+    }
 
     extend self
 


### PR DESCRIPTION


<!--
Thanks so much for the contribution!

If you're updating documentation, make sure you run `bin/rake man:build` and
squash the result into your changes, so that all documentation formats are
updated.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

### What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

Running `bin/rake spec:deps` from jruby crashes with:

```
rake aborted!
FrozenError: can't modify frozen Hash
/path/to/bundler/spec/support/rubygems_ext.rb:36:in `dev_setup'
/path/to/bundler/Rakefile:29:in `block in <main>'
/path/to/bundler/Rakefile:14:in `block in invoke'
/path/to/bundler/Rakefile:13:in `invoke'
/path/to/bundler/spec/support/rubygems_ext.rb:98:in `gem_load_and_activate'
/path/to/bundler/spec/support/rubygems_ext.rb:45:in `gem_load'
Tasks: TOP => spec:deps
(See full trace by running task with --trace)
```

### What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

Unfreeze the hashes, since we are modifying them.