### PR TITLE
Pin jruby-jars in warbler test

### DIFF
--- a/spec/realworld/fixtures/warbler/.gitignore
+++ b/spec/realworld/fixtures/warbler/.gitignore
@@ -1,2 +1,1 @@
 *.jar
-Gemfile.lock

--- a/spec/realworld/fixtures/warbler/Gemfile.lock
+++ b/spec/realworld/fixtures/warbler/Gemfile.lock
@@ -1,0 +1,29 @@
+PATH
+  remote: demo
+  specs:
+    demo (1.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    jruby-jars (9.2.9.0)
+    jruby-rack (1.1.21)
+    rake (13.0.1)
+    rubyzip (1.3.0)
+    warbler (2.0.5)
+      jruby-jars (>= 9.0.0.0)
+      jruby-rack (>= 1.1.1, < 1.3)
+      rake (>= 10.1.0)
+      rubyzip (~> 1.0, < 1.4)
+
+PLATFORMS
+  java
+  ruby
+
+DEPENDENCIES
+  demo!
+  jruby-jars (~> 9.2)
+  warbler (~> 2.0)
+
+BUNDLED WITH
+   2.2.0.dev


### PR DESCRIPTION


<!--
Thanks so much for the contribution!

If you're updating documentation, make sure you run `bin/rake man:build` and
squash the result into your changes, so that all documentation formats are
updated.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

### What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

The problem is that our CI is broken after the jruby-9.2.10.0 release.

### What is your fix for the problem, implemented in this PR?

My workaround is to pin the jruby-jars dependency of the warbler test to 9.2.9.0.

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->