### PR TITLE
Fix resolving specs when run against a dev ruby snapshot

### DIFF
--- a/spec/install/gems/resolving_spec.rb
+++ b/spec/install/gems/resolving_spec.rb
@@ -233,7 +233,7 @@ RSpec.describe "bundle install with install-time dependencies" do
 
       describe "with a < requirement" do
         let(:ruby_requirement) { %("< 5000") }
-        let(:error_message_requirement) { Gem::Requirement.new(["< 5000", "= #{RUBY_VERSION}.#{RUBY_PATCHLEVEL}"]).to_s }
+        let(:error_message_requirement) { Gem::Requirement.new(["< 5000", "= #{Bundler::RubyVersion.system.to_gem_version_with_patchlevel}"]).to_s }
 
         it_behaves_like "ruby version conflicts"
       end
@@ -241,7 +241,7 @@ RSpec.describe "bundle install with install-time dependencies" do
       describe "with a compound requirement" do
         let(:reqs) { ["> 0.1", "< 5000"] }
         let(:ruby_requirement) { reqs.map(&:dump).join(", ") }
-        let(:error_message_requirement) { Gem::Requirement.new(reqs + ["= #{RUBY_VERSION}.#{RUBY_PATCHLEVEL}"]).to_s }
+        let(:error_message_requirement) { Gem::Requirement.new(reqs + ["= #{Bundler::RubyVersion.system.to_gem_version_with_patchlevel}"]).to_s }
 
         it_behaves_like "ruby version conflicts"
       end


### PR DESCRIPTION

<!--
Thanks so much for the contribution!

If you're updating documentation, make sure you run `bin/rake man:build` and
squash the result into your changes, so that all documentation formats are
updated.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

### What was the end-user or developer problem that led to this PR?

The problem is that in some dev ruby builds, `RUBY_PATCHLEVEL` is `-1`, so the spec crashes because of an ill-formed requirement.

See for example https://github.com/rubygems/rubygems/pull/3077/checks?check_run_id=457988784.

<!-- Write a clear and complete description of the problem -->

### What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

My fix is to change the spec to respect a `RUBY_PATCHLEVEL` equal to `-1`, by reusing code that handles that case.