### PR TITLE
Bump rake version to 13.0 everywhere

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ script:
   - BUNDLER_SPEC_PRE_RECORDED=1 bin/rake spec:realworld
 
 before_script:
-  - travis_retry gem install rake:"~> 12.0"
   - travis_retry bin/rake override_version
   - travis_retry bin/rake spec:parallel_deps
   - if [ "$BUNDLER_SPEC_SUB_VERSION" = "" ];

--- a/lib/bundler/templates/newgem/Gemfile.tt
+++ b/lib/bundler/templates/newgem/Gemfile.tt
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in <%= config[:name] %>.gemspec
 gemspec
 
-gem "rake", "~> 12.0"
+gem "rake", "~> 13.0"
 <%- if config[:ext] -%>
 gem "rake-compiler"
 <%- end -%>

--- a/spec/commands/lock_spec.rb
+++ b/spec/commands/lock_spec.rb
@@ -38,8 +38,8 @@ RSpec.describe "bundle lock" do
             actionpack (= 2.3.2)
             activerecord (= 2.3.2)
             activeresource (= 2.3.2)
-            rake (= 12.3.2)
-          rake (12.3.2)
+            rake (= 13.0.1)
+          rake (13.0.1)
           with_license (1.0)
 
       PLATFORMS
@@ -133,7 +133,7 @@ RSpec.describe "bundle lock" do
   end
 
   it "update specific gems using --update" do
-    lockfile @lockfile.gsub("2.3.2", "2.3.1").gsub("12.3.2", "10.0.1")
+    lockfile @lockfile.gsub("2.3.2", "2.3.1").gsub("13.0.1", "10.0.1")
 
     bundle "lock --update rails rake"
 

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -251,7 +251,7 @@ RSpec.describe "bundle gem" do
 
     prepare_gemspec(bundled_app("newgem", "newgem.gemspec"))
 
-    gems = ["rake-12.3.2"]
+    gems = ["rake-13.0.1"]
     system_gems gems, :path => :bundle_path, :bundle_dir => bundled_app("newgem")
     bundle! "exec rake build", :dir => bundled_app("newgem")
 
@@ -359,7 +359,7 @@ RSpec.describe "bundle gem" do
     it "runs rake without problems" do
       bundle! "gem #{gem_name}"
 
-      system_gems ["rake-12.3.2"]
+      system_gems ["rake-13.0.1"]
 
       rakefile = strip_whitespace <<-RAKEFILE
         task :default do

--- a/spec/commands/show_spec.rb
+++ b/spec/commands/show_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe "bundle show", :bundler => "< 3" do
     it "prints path of all gems in bundle sorted by name" do
       bundle! "show --paths"
 
-      expect(out).to include(default_bundle_path("gems", "rake-12.3.2").to_s)
+      expect(out).to include(default_bundle_path("gems", "rake-13.0.1").to_s)
       expect(out).to include(default_bundle_path("gems", "rails-2.3.2").to_s)
 
       # Gem names are the last component of their path.

--- a/spec/install/gemfile/gemspec_spec.rb
+++ b/spec/install/gemfile/gemspec_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe "bundle install from an existing gemspec" do
     build_lib("foo", :path => tmp.join("foo")) do |s|
       s.write("Gemfile", "source '#{file_uri_for(gem_repo1)}'\ngemspec")
       s.add_dependency "actionpack", "=2.3.2"
-      s.add_development_dependency "rake", "=12.3.2"
+      s.add_development_dependency "rake", "=13.0.1"
     end
 
     bundle "install", :dir => tmp.join("foo")

--- a/spec/install/gems/compact_index_spec.rb
+++ b/spec/install/gems/compact_index_spec.rb
@@ -1015,7 +1015,7 @@ The checksum of /versions does not match the checksum provided by the server! So
       source "#{source_uri}"
       gem "rails"
     G
-    deps = [Gem::Dependency.new("rake", "= 12.3.2"),
+    deps = [Gem::Dependency.new("rake", "= 13.0.1"),
             Gem::Dependency.new("actionpack", "= 2.3.2"),
             Gem::Dependency.new("activerecord", "= 2.3.2"),
             Gem::Dependency.new("actionmailer", "= 2.3.2"),

--- a/spec/lock/lockfile_spec.rb
+++ b/spec/lock/lockfile_spec.rb
@@ -748,8 +748,8 @@ RSpec.describe "the lockfile format" do
             actionpack (= 2.3.2)
             activerecord (= 2.3.2)
             activeresource (= 2.3.2)
-            rake (= 12.3.2)
-          rake (12.3.2)
+            rake (= 13.0.1)
+          rake (13.0.1)
 
       PLATFORMS
         #{lockfile_platforms}

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -159,7 +159,7 @@ RSpec.describe "Bundler.setup" do
         "/gems/actionpack-2.3.2/lib",
         "/gems/actionmailer-2.3.2/lib",
         "/gems/activesupport-2.3.2/lib",
-        "/gems/rake-12.3.2/lib"
+        "/gems/rake-13.0.1/lib"
       )
     end
 

--- a/spec/support/builders.rb
+++ b/spec/support/builders.rb
@@ -40,7 +40,7 @@ module Spec
 
         build_gem "rails", "2.3.2" do |s|
           s.executables = "rails"
-          s.add_dependency "rake",           "12.3.2"
+          s.add_dependency "rake",           "13.0.1"
           s.add_dependency "actionpack",     "2.3.2"
           s.add_dependency "activerecord",   "2.3.2"
           s.add_dependency "actionmailer",   "2.3.2"

--- a/spec/support/rubygems_ext.rb
+++ b/spec/support/rubygems_ext.rb
@@ -20,7 +20,7 @@ module Spec
       "compact_index" => "~> 0.11.0",
       "sinatra" => "~> 2.0",
       # Rake version has to be consistent for tests to pass
-      "rake" => "12.3.2",
+      "rake" => "13.0.1",
       "builder" => "~> 3.2",
       # ruby-graphviz is used by the viz tests
       "ruby-graphviz" => ">= 0.a",

--- a/spec/support/rubygems_ext.rb
+++ b/spec/support/rubygems_ext.rb
@@ -7,7 +7,6 @@ module Spec
     DEV_DEPS = { # rubocop:disable Style/MutableConstant
       "automatiek" => "~> 0.3.0",
       "parallel_tests" => "~> 2.29",
-      "rake" => "~> 12.0",
       "ronn" => "~> 0.7.3",
       "rspec" => "~> 3.8",
       "rubocop" => "= 0.77.0",


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

If you're updating documentation, make sure you run `bin/rake man:build` and
squash the result into your changes, so that all documentation formats are
updated.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

### What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

The problem is rake 12 prints a bunch of warnings on ruby 2.7.

### What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

My fix is to upgrade rake everywhere.