### PR TITLE
Revise CoC based on Contributor Covenant 2.0

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,136 +1,81 @@
 # Bundler Code of Conduct
 
-## When Something Happens
-
-If you see a Code of Conduct violation, follow these steps:
-
-1.  Let the person know that what they did is not appropriate and ask them to stop and/or edit their message(s).
-2.  That person should immediately stop the behavior and correct the issue.
-3.  If this doesn't happen, or if you're uncomfortable speaking up, [contact admins](#contacting-admins).
-4.  As soon as available, an admin will join, identify themselves, and take [further action (see below)](#further-enforcement), starting with a warning, then temporary deactivation, then long-term deactivation.
-
-When reporting, please include any relevant details, links, screenshots, context, or other information that may be used to better understand and resolve the situation.
-
-**The admin team will prioritize the well-being and comfort of the recipients of the violation over the comfort of the violator.** See [some examples below](#enforcement-examples).
-
 ## Our Pledge
 
-In the interest of fostering an open and welcoming environment, we as members of the Bundler community pledge to making participation in our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, technical preferences, nationality, personal appearance, race, religion, or sexual identity and orientation.
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
 
 ## Our Standards
 
-Examples of behavior that contributes to creating a positive environment include:
+Examples of behavior that contributes to a positive environment for our community include:
 
--   Using welcoming and inclusive language.
--   Being respectful of differing viewpoints and experiences.
--   Gracefully accepting constructive feedback.
--   Focusing on what is best for the community.
--   Showing empathy and kindness towards other community members.
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
 
-Examples of unacceptable behavior by participants include:
+Examples of unacceptable behavior include:
 
--   The use of sexualized language or imagery and unwelcome sexual attention or advances, including when simulated online. The only exception to sexual topics is channels/spaces specifically for topics of sexual identity.
--   Trolling, insulting/derogatory comments, and personal or political attacks.
--   Casual mention of slavery or indentured servitude and/or false comparisons of one's occupation or situation to slavery. Please consider using or asking about alternate terminology when referring to such metaphors in technology.
--   Making light of/making mocking comments about trigger warnings and content warnings.
--   Public or private harassment, deliberate intimidation, or threats.
--   Publishing others' private information, such as a physical or electronic address, without explicit permission. This includes any sort of "outing" of any aspect of someone's identity without their consent.
--   Publishing screenshots or quotes, especially from identity channels, without all quoted users' _explicit_ consent.
--   Publishing or telling others that a member belongs to a particular identity channel without asking their consent first.
--   Publishing of non-harassing private communication.
--   Any of the above even when [presented as "ironic" or "joking"](https://en.wikipedia.org/wiki/Hipster_racism).
--   Any attempt to present "reverse-ism" versions of the above as violations. Examples of reverse-isms are "reverse racism", "reverse sexism", "heterophobia", and "cisphobia".
--   Unsolicited explanations under the assumption that someone doesn't already know it. Ask before you teach! Don't assume what people's knowledge gaps are.
--   [Feigning or exaggerating surprise](https://www.recurse.com/manual#no-feigned-surprise) when someone admits to not knowing something.
--   "[Well-actuallies](https://www.recurse.com/manual#no-well-actuallys)"
--   Other conduct which could reasonably be considered inappropriate in a professional or community setting.
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
 
 ## Scope
 
-This Code of Conduct applies both within community spaces and in other spaces involving the community. This includes the GitHub repository, the Bundler Slack instance, the Bundler Twitter community, private email communications in the context of the community, and any events where members of the community are participating, as well as adjacent communities and venues affecting the community's members.
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
 
-Depending on the violation, the admins may decide that violations of this code of conduct that have happened outside of the scope of the community may deem an individual unwelcome, and take appropriate action to maintain the comfort and safety of its members.
+## Enforcement
 
-This Code of Conduct is detailed for the purpose of removing ambiguity, not for the sake of strictness. It is the sincere hope of admins that it helps foster mutual understanding, and the creation of a space where everyone can participate in a way relevant to the project itself, without things going horribly due to accidental/well-intentioned toe stepping. Please be kind to one another!
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at team@bundler.io, or directly contacting project team members via email or Slack. All complaints will be reviewed and investigated promptly and fairly.
 
-## Admin Enforcement Process
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 
-Once the admins get involved, they will follow a documented series of steps and do their best to preserve the well-being of community members. This section covers actual concrete steps.
+## Enforcement Guidelines
 
-### Contacting Admins
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
 
-You may get in touch with the Bundler admin team through any of the following methods:
+### 1. Correction
 
-- Email [the Bundler maintainers](https://bundler.io/contributors.html) as a group at [team@bundler.io](mailto:team@bundler.io).
-- Directly message any maintainer in private (through Slack, Twitter, email, or other available option) if that is more comfortable
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
 
-### Further Enforcement
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
 
-If you've already followed the [initial enforcement steps](#enforcement), these are the steps admins will take for further enforcement, as needed:
+### 2. Warning
 
-1.  Repeat the request to stop.
-2.  If the person doubles down, they will be removed from the discussion (where possible), and given an official warning.
-3.  If the behavior continues or is repeated later, the person will be blocked/deactivated for 24 hours.
-4.  If the behavior continues or is repeated after the temporary deactivation, a long-term (6-12mo) deactivation will be used.
+**Community Impact**: A violation through a single incident or series of actions.
 
-On top of this, admins may remove any offending messages, images, contributions, etc, as they deem necessary.
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
 
-Admins reserve full rights to skip any of these steps, at their discretion, if the violation is considered to be a serious and/or immediate threat to the health and well-being of members of the community. These include any threats, serious physical or verbal attacks, and other such behavior that would be completely unacceptable in any social setting that puts our members at risk.
+### 3. Temporary Ban
 
-Members expelled from events or venues with any sort of paid attendance will not be refunded.
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
 
-### Who Watches the Watchers?
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
 
-Admins and other leaders who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the community's leadership. These may include anything from removal from the admin team to a permanent ban from the community.
+### 4. Permanent Ban
 
-### Enforcement Examples
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior,  harassment of an individual, or aggression toward or disparagement of classes of individuals.
 
-#### The Best Case
-
-The vast majority of situations work out like this, in our experience. This interaction is common, and generally positive.
-
-> Alex: "Yeah I used X and it was really crazy!"
-
-> Patt: "Hey, could you not use that word? What about 'ridiculous' instead?"
-
-> Alex: "oh sorry, sure." -> edits old message to say "it was really confusing!"
-
-#### The Admin Case
-
-Sometimes, though, you need to get admins involved. Admins will do their best to resolve conflicts, but people who were harmed by something **will take priority**.
-
-> Patt: "Honestly, sometimes I just really hate using $language and anyone who uses it probably sucks at their job."
-
-> Alex: "Whoa there, could you dial it back a bit? There's a CoC thing about attacking folks' tech use like that."
-
-> Patt: "I'm not attacking anyone, are you deaf?"
-
-> Alex: _DMs admin_ "hey uh. Can someone look at #general? Patt is getting a bit aggro. I tried to nudge them about it, but nope."
-
-> MxAdmin1: <joins #general> "Hey Patt, admin here. Could you tone it down? This sort of attack is really not okay in this space."
-
-> Patt: "Leave me alone I haven't said anything bad wtf is wrong with you."
-
-> MxAdmin1: _removes patt_ _DMs patt_ "I mean it. Please refer to the CoC over at bundler.io/conduct.html if you have questions, but you can consider this an actual warning. I'd appreciate it if you reworded your messages in #general, since they made folks there uncomfortable. Let's try and be kind, yeah?"
-
-> Patt: _Replies to DM_ "@mxadmin1 Okay sorry. I'm just frustrated and I'm kinda burnt out and I guess I got carried away. I'll DM Alex a note apologizing and edit my messages. Sorry for the trouble."
-
-> MxAdmin1: _Replies to DM_ "@patt Thanks for that. I hear you on the stress. Burnout sucks :/. Have a good one!"
-
-#### The Nope Case
-
-> PepeTheFrog🐸: "Hi, I am a literal actual nazi and I think white supremacists are quite fashionable."
-
-> Patt: "NOOOOPE. OH NOPE NOPE."
-
-> Alex: "JFC NO. NOPE. `/admin nope nope nope @ #javascript`"
-
-> MxAdmin1: "👀 Nope. NOPE NOPE NOPE. 🔥"
-
-> PepeTheFrog🐸 has been deactivated.
+**Consequence**: A permanent ban from any sort of public interaction within the community.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [package.community Code of Conduct], adapted from the [WeAllJS Code of Conduct](https://wealljs.org/code-of-conduct), itself adapted from [Contributor Covenant](https://contributor-covenant.org) version 1.4, available at [https://contributor-covenant.org/version/1/4](https://contributor-covenant.org/version/1/4), as well as the LGBTQ in Technology Slack [Code of Conduct](https://lgbtq.technology/coc.html).
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.0,
+available at https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
 
-Additional thanks to [Contributor Covenant](https://contributor-covenant.org) for the [default code of conduct](https://github.com/rubygems/bundler/blob/master/lib/bundler/templates/newgem/CODE_OF_CONDUCT.md.tt) included in generated gems.
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at https://www.contributor-covenant.org/translations.


### PR DESCRIPTION
Bundler has had a code of conduct since before the Contributor Covenant was available as an option. In my (admittedly somewhat vague) memory, we continued to use our own custom CoC based on wanting clear enforcement examples directly in the CoC. The Contributor Covenant now contains enforcement examples as of 2.0, so I am proposing that we migrate Bundler's CoC to CC 2.0.

Additional benefits:
  - Merging with RubyGems gets easier, since RubyGems uses CC already (rubygems/rubygems#3157).
  - The `bundle gem` template and Bundler itself will now use the same CoC.