### PR TITLE
Bump man pages month

### DIFF
--- a/man/bundle-add.1
+++ b/man/bundle-add.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-ADD" "1" "February 2020" "" ""
+.TH "BUNDLE\-ADD" "1" "March 2020" "" ""
 .
 .SH "NAME"
 \fBbundle\-add\fR \- Add gem to the Gemfile and run bundle install

--- a/man/bundle-add.1.txt
+++ b/man/bundle-add.1.txt
@@ -55,4 +55,4 @@ OPTIONS
 
 
 
-				 February 2020			 BUNDLE-ADD(1)
+				  March 2020			 BUNDLE-ADD(1)

--- a/man/bundle-binstubs.1
+++ b/man/bundle-binstubs.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-BINSTUBS" "1" "February 2020" "" ""
+.TH "BUNDLE\-BINSTUBS" "1" "March 2020" "" ""
 .
 .SH "NAME"
 \fBbundle\-binstubs\fR \- Install the binstubs of the listed gems

--- a/man/bundle-binstubs.1.txt
+++ b/man/bundle-binstubs.1.txt
@@ -45,4 +45,4 @@ BUNDLE INSTALL --BINSTUBS
 
 
 
-				 February 2020		    BUNDLE-BINSTUBS(1)
+				  March 2020		    BUNDLE-BINSTUBS(1)

--- a/man/bundle-cache.1
+++ b/man/bundle-cache.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-CACHE" "1" "February 2020" "" ""
+.TH "BUNDLE\-CACHE" "1" "March 2020" "" ""
 .
 .SH "NAME"
 \fBbundle\-cache\fR \- Package your needed \fB\.gem\fR files into your application

--- a/man/bundle-cache.1.txt
+++ b/man/bundle-cache.1.txt
@@ -75,4 +75,4 @@ REMOTE FETCHING
 
 
 
-				 February 2020		       BUNDLE-CACHE(1)
+				  March 2020		       BUNDLE-CACHE(1)

--- a/man/bundle-check.1
+++ b/man/bundle-check.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-CHECK" "1" "February 2020" "" ""
+.TH "BUNDLE\-CHECK" "1" "March 2020" "" ""
 .
 .SH "NAME"
 \fBbundle\-check\fR \- Verifies if dependencies are satisfied by installed gems

--- a/man/bundle-check.1.txt
+++ b/man/bundle-check.1.txt
@@ -30,4 +30,4 @@ OPTIONS
 
 
 
-				 February 2020		       BUNDLE-CHECK(1)
+				  March 2020		       BUNDLE-CHECK(1)

--- a/man/bundle-clean.1
+++ b/man/bundle-clean.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-CLEAN" "1" "February 2020" "" ""
+.TH "BUNDLE\-CLEAN" "1" "March 2020" "" ""
 .
 .SH "NAME"
 \fBbundle\-clean\fR \- Cleans up unused gems in your bundler directory

--- a/man/bundle-clean.1.txt
+++ b/man/bundle-clean.1.txt
@@ -23,4 +23,4 @@ OPTIONS
 
 
 
-				 February 2020		       BUNDLE-CLEAN(1)
+				  March 2020		       BUNDLE-CLEAN(1)

--- a/man/bundle-config.1
+++ b/man/bundle-config.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-CONFIG" "1" "February 2020" "" ""
+.TH "BUNDLE\-CONFIG" "1" "March 2020" "" ""
 .
 .SH "NAME"
 \fBbundle\-config\fR \- Set bundler configuration options

--- a/man/bundle-config.1.txt
+++ b/man/bundle-config.1.txt
@@ -522,4 +522,4 @@ CONFIGURE BUNDLER DIRECTORIES
 
 
 
-				 February 2020		      BUNDLE-CONFIG(1)
+				  March 2020		      BUNDLE-CONFIG(1)

--- a/man/bundle-doctor.1
+++ b/man/bundle-doctor.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-DOCTOR" "1" "February 2020" "" ""
+.TH "BUNDLE\-DOCTOR" "1" "March 2020" "" ""
 .
 .SH "NAME"
 \fBbundle\-doctor\fR \- Checks the bundle for common problems

--- a/man/bundle-doctor.1.txt
+++ b/man/bundle-doctor.1.txt
@@ -41,4 +41,4 @@ OPTIONS
 
 
 
-				 February 2020		      BUNDLE-DOCTOR(1)
+				  March 2020		      BUNDLE-DOCTOR(1)

--- a/man/bundle-exec.1
+++ b/man/bundle-exec.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-EXEC" "1" "February 2020" "" ""
+.TH "BUNDLE\-EXEC" "1" "March 2020" "" ""
 .
 .SH "NAME"
 \fBbundle\-exec\fR \- Execute a command in the context of the bundle

--- a/man/bundle-exec.1.txt
+++ b/man/bundle-exec.1.txt
@@ -175,4 +175,4 @@ RUBYGEMS PLUGINS
 
 
 
-				 February 2020			BUNDLE-EXEC(1)
+				  March 2020			BUNDLE-EXEC(1)

--- a/man/bundle-gem.1
+++ b/man/bundle-gem.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-GEM" "1" "February 2020" "" ""
+.TH "BUNDLE\-GEM" "1" "March 2020" "" ""
 .
 .SH "NAME"
 \fBbundle\-gem\fR \- Generate a project skeleton for creating a rubygem

--- a/man/bundle-gem.1.txt
+++ b/man/bundle-gem.1.txt
@@ -88,4 +88,4 @@ SEE ALSO
 
 
 
-				 February 2020			 BUNDLE-GEM(1)
+				  March 2020			 BUNDLE-GEM(1)

--- a/man/bundle-info.1
+++ b/man/bundle-info.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-INFO" "1" "February 2020" "" ""
+.TH "BUNDLE\-INFO" "1" "March 2020" "" ""
 .
 .SH "NAME"
 \fBbundle\-info\fR \- Show information for the given gem in your bundle

--- a/man/bundle-info.1.txt
+++ b/man/bundle-info.1.txt
@@ -18,4 +18,4 @@ OPTIONS
 
 
 
-				 February 2020			BUNDLE-INFO(1)
+				  March 2020			BUNDLE-INFO(1)

--- a/man/bundle-init.1
+++ b/man/bundle-init.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-INIT" "1" "February 2020" "" ""
+.TH "BUNDLE\-INIT" "1" "March 2020" "" ""
 .
 .SH "NAME"
 \fBbundle\-init\fR \- Generates a Gemfile into the current working directory

--- a/man/bundle-init.1.txt
+++ b/man/bundle-init.1.txt
@@ -31,4 +31,4 @@ SEE ALSO
 
 
 
-				 February 2020			BUNDLE-INIT(1)
+				  March 2020			BUNDLE-INIT(1)

--- a/man/bundle-inject.1
+++ b/man/bundle-inject.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-INJECT" "1" "February 2020" "" ""
+.TH "BUNDLE\-INJECT" "1" "March 2020" "" ""
 .
 .SH "NAME"
 \fBbundle\-inject\fR \- Add named gem(s) with version requirements to Gemfile

--- a/man/bundle-inject.1.txt
+++ b/man/bundle-inject.1.txt
@@ -29,4 +29,4 @@ DESCRIPTION
 
 
 
-				 February 2020		      BUNDLE-INJECT(1)
+				  March 2020		      BUNDLE-INJECT(1)

--- a/man/bundle-install.1
+++ b/man/bundle-install.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-INSTALL" "1" "February 2020" "" ""
+.TH "BUNDLE\-INSTALL" "1" "March 2020" "" ""
 .
 .SH "NAME"
 \fBbundle\-install\fR \- Install the dependencies specified in your Gemfile

--- a/man/bundle-install.1.txt
+++ b/man/bundle-install.1.txt
@@ -398,4 +398,4 @@ SEE ALSO
 
 
 
-				 February 2020		     BUNDLE-INSTALL(1)
+				  March 2020		     BUNDLE-INSTALL(1)

--- a/man/bundle-list.1
+++ b/man/bundle-list.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-LIST" "1" "February 2020" "" ""
+.TH "BUNDLE\-LIST" "1" "March 2020" "" ""
 .
 .SH "NAME"
 \fBbundle\-list\fR \- List all the gems in the bundle

--- a/man/bundle-list.1.txt
+++ b/man/bundle-list.1.txt
@@ -41,4 +41,4 @@ OPTIONS
 
 
 
-				 February 2020			BUNDLE-LIST(1)
+				  March 2020			BUNDLE-LIST(1)

--- a/man/bundle-lock.1
+++ b/man/bundle-lock.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-LOCK" "1" "February 2020" "" ""
+.TH "BUNDLE\-LOCK" "1" "March 2020" "" ""
 .
 .SH "NAME"
 \fBbundle\-lock\fR \- Creates / Updates a lockfile without installing

--- a/man/bundle-lock.1.txt
+++ b/man/bundle-lock.1.txt
@@ -90,4 +90,4 @@ PATCH LEVEL OPTIONS
 
 
 
-				 February 2020			BUNDLE-LOCK(1)
+				  March 2020			BUNDLE-LOCK(1)

--- a/man/bundle-open.1
+++ b/man/bundle-open.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-OPEN" "1" "February 2020" "" ""
+.TH "BUNDLE\-OPEN" "1" "March 2020" "" ""
 .
 .SH "NAME"
 \fBbundle\-open\fR \- Opens the source directory for a gem in your bundle

--- a/man/bundle-open.1.txt
+++ b/man/bundle-open.1.txt
@@ -26,4 +26,4 @@ DESCRIPTION
 
 
 
-				 February 2020			BUNDLE-OPEN(1)
+				  March 2020			BUNDLE-OPEN(1)

--- a/man/bundle-outdated.1
+++ b/man/bundle-outdated.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-OUTDATED" "1" "February 2020" "" ""
+.TH "BUNDLE\-OUTDATED" "1" "March 2020" "" ""
 .
 .SH "NAME"
 \fBbundle\-outdated\fR \- List installed gems with newer versions available

--- a/man/bundle-outdated.1.txt
+++ b/man/bundle-outdated.1.txt
@@ -128,4 +128,4 @@ FILTERING OUTPUT
 
 
 
-				 February 2020		    BUNDLE-OUTDATED(1)
+				  March 2020		    BUNDLE-OUTDATED(1)

--- a/man/bundle-platform.1
+++ b/man/bundle-platform.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-PLATFORM" "1" "February 2020" "" ""
+.TH "BUNDLE\-PLATFORM" "1" "March 2020" "" ""
 .
 .SH "NAME"
 \fBbundle\-platform\fR \- Displays platform compatibility information

--- a/man/bundle-platform.1.txt
+++ b/man/bundle-platform.1.txt
@@ -54,4 +54,4 @@ OPTIONS
 
 
 
-				 February 2020		    BUNDLE-PLATFORM(1)
+				  March 2020		    BUNDLE-PLATFORM(1)

--- a/man/bundle-pristine.1
+++ b/man/bundle-pristine.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-PRISTINE" "1" "February 2020" "" ""
+.TH "BUNDLE\-PRISTINE" "1" "March 2020" "" ""
 .
 .SH "NAME"
 \fBbundle\-pristine\fR \- Restores installed gems to their pristine condition

--- a/man/bundle-pristine.1.txt
+++ b/man/bundle-pristine.1.txt
@@ -41,4 +41,4 @@ DESCRIPTION
 
 
 
-				 February 2020		    BUNDLE-PRISTINE(1)
+				  March 2020		    BUNDLE-PRISTINE(1)

--- a/man/bundle-remove.1
+++ b/man/bundle-remove.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-REMOVE" "1" "February 2020" "" ""
+.TH "BUNDLE\-REMOVE" "1" "March 2020" "" ""
 .
 .SH "NAME"
 \fBbundle\-remove\fR \- Removes gems from the Gemfile

--- a/man/bundle-remove.1.txt
+++ b/man/bundle-remove.1.txt
@@ -31,4 +31,4 @@ OPTIONS
 
 
 
-				 February 2020		      BUNDLE-REMOVE(1)
+				  March 2020		      BUNDLE-REMOVE(1)

--- a/man/bundle-show.1
+++ b/man/bundle-show.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-SHOW" "1" "February 2020" "" ""
+.TH "BUNDLE\-SHOW" "1" "March 2020" "" ""
 .
 .SH "NAME"
 \fBbundle\-show\fR \- Shows all the gems in your bundle, or the path to a gem

--- a/man/bundle-show.1.txt
+++ b/man/bundle-show.1.txt
@@ -24,4 +24,4 @@ OPTIONS
 
 
 
-				 February 2020			BUNDLE-SHOW(1)
+				  March 2020			BUNDLE-SHOW(1)

--- a/man/bundle-update.1
+++ b/man/bundle-update.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-UPDATE" "1" "February 2020" "" ""
+.TH "BUNDLE\-UPDATE" "1" "March 2020" "" ""
 .
 .SH "NAME"
 \fBbundle\-update\fR \- Update your gems to the latest available versions

--- a/man/bundle-update.1.txt
+++ b/man/bundle-update.1.txt
@@ -387,4 +387,4 @@ RECOMMENDED WORKFLOW
 
 
 
-				 February 2020		      BUNDLE-UPDATE(1)
+				  March 2020		      BUNDLE-UPDATE(1)

--- a/man/bundle-viz.1
+++ b/man/bundle-viz.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE\-VIZ" "1" "February 2020" "" ""
+.TH "BUNDLE\-VIZ" "1" "March 2020" "" ""
 .
 .SH "NAME"
 \fBbundle\-viz\fR \- Generates a visual dependency graph for your Gemfile

--- a/man/bundle-viz.1.txt
+++ b/man/bundle-viz.1.txt
@@ -36,4 +36,4 @@ OPTIONS
 
 
 
-				 February 2020			 BUNDLE-VIZ(1)
+				  March 2020			 BUNDLE-VIZ(1)

--- a/man/bundle.1
+++ b/man/bundle.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BUNDLE" "1" "February 2020" "" ""
+.TH "BUNDLE" "1" "March 2020" "" ""
 .
 .SH "NAME"
 \fBbundle\fR \- Ruby Dependency Management

--- a/man/bundle.1.txt
+++ b/man/bundle.1.txt
@@ -113,4 +113,4 @@ OBSOLETE
 
 
 
-				 February 2020			     BUNDLE(1)
+				  March 2020			     BUNDLE(1)

--- a/man/gemfile.5
+++ b/man/gemfile.5
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GEMFILE" "5" "February 2020" "" ""
+.TH "GEMFILE" "5" "March 2020" "" ""
 .
 .SH "NAME"
 \fBGemfile\fR \- A format for describing gem dependencies for Ruby programs

--- a/man/gemfile.5.txt
+++ b/man/gemfile.5.txt
@@ -646,4 +646,4 @@ SOURCE PRIORITY
 
 
 
-				 February 2020			    GEMFILE(5)
+				  March 2020			    GEMFILE(5)


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

If you're updating documentation, make sure you run `bin/rake man:build` and
squash the result into your changes, so that all documentation formats are
updated.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

### What was the end-user or developer problem that led to this PR?

CI fails when man pages month gets out of date.

### What is your fix for the problem, implemented in this PR?

My fix is to update the month in the man pages to the current one.