### PR TITLE
Fix sudo specs environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 dist: bionic
 script:
   - bin/parallel_rspec spec
+  - sudo sed -i '/secure_path/d' /etc/sudoers
   - test "$(ruby -v)" = "$(sudo -E ruby -v)"
   - sudo -E bin/rake spec:sudo
   - sudo chown -R $(whoami) tmp
@@ -14,7 +15,6 @@ before_script:
     then
       travis_retry sudo apt-get install graphviz -y;
     fi
-    sudo sed -i '/secure_path/d' /etc/sudoers;
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,7 @@ language: ruby
 dist: bionic
 script:
   - bin/parallel_rspec spec
-  - sudo sed -i '/secure_path/d' /etc/sudoers
-  - test "$(ruby -v)" = "$(sudo -E ruby -v)"
-  - sudo -E bin/rake spec:sudo
-  - sudo chown -R $(whoami) tmp
+  - bin/rake spec:sudo
   - BUNDLER_SPEC_PRE_RECORDED=1 bin/rake spec:realworld
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ before_script:
     fi
   - if [ "$TRAVIS_RUBY_VERSION" = "2.3.8" ];
     then
-      sudo sed -i 's/1000::/1000:Travis:/g' /etc/passwd;
       sudo sed -i '/secure_path/d' /etc/sudoers;
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 dist: bionic
 script:
   - bin/parallel_rspec spec
+  - test "$(ruby -v)" = "$(sudo -E ruby -v)"
   - sudo -E bin/rake spec:sudo
   - sudo chown -R $(whoami) tmp
   - BUNDLER_SPEC_PRE_RECORDED=1 bin/rake spec:realworld
@@ -13,10 +14,7 @@ before_script:
     then
       travis_retry sudo apt-get install graphviz -y;
     fi
-  - if [ "$TRAVIS_RUBY_VERSION" = "2.3.8" ];
-    then
-      sudo sed -i '/secure_path/d' /etc/sudoers;
-    fi
+    sudo sed -i '/secure_path/d' /etc/sudoers;
 
 branches:
   only:

--- a/Rakefile
+++ b/Rakefile
@@ -57,15 +57,18 @@ namespace :spec do
   desc "Run the spec suite with the sudo tests"
   task :sudo => %w[set_sudo] do
     require "open3"
-
-    output, status = Open3.capture2e("sudo sed -i '/secure_path/d' /etc/sudoers")
-    raise "Couldn't configure sudo to preserve path: #{output}" unless status.success?
-
-    raise "Couldn't configure sudo correctly to preserve path" unless `ruby -v` == `sudo -E ruby -v`
+    output, status = Open3.capture2e("sudo", "cp", "/etc/sudoers", "tmp/old_sudoers")
+    raise "Couldn't read sudoers file: #{output}" unless status.success?
 
     begin
+      output, status = Open3.capture2e("sudo sed -i '/secure_path/d' /etc/sudoers")
+      raise "Couldn't configure sudo to preserve path: #{output}" unless status.success?
+
+      raise "Couldn't configure sudo correctly to preserve path" unless `ruby -v` == `sudo -E ruby -v`
+
       sh("sudo -E bin/rspec")
     ensure
+      system("sudo", "cp", "tmp/old_sudoers", "/etc/sudoers")
       system("sudo", "chown", "-R", ENV["USER"], "tmp")
     end
   end


### PR DESCRIPTION
### What was the end-user or developer problem that led to this PR?

The developer problem is that sudo specs are not correctly setting the environment (except for ruby 2.3). The specs are accidentally passing but you can tell that they are running against the system ruby by the [warning messages they print](https://travis-ci.org/rubygems/bundler/jobs/658272719#L531-L558).

This causes problems when migrating to github actions. See https://github.com/rubygems/bundler/pull/7660#discussion_r385616844.

Another problem is that the environment is setup manually outside of `rake spec:sudo`, so there's no easy way of running sudo specs manually if your system does not have the right sudoers configuration.

### What is your fix for the problem, implemented in this PR?

My fix is to properly set sudo configuration to preserve the environment so that the correct ruby can be found by sudo specs, and also to move the logic inside `rake spec:sudo` so that the specs can easily be run manually without side effects.
