### PR TITLE
Fix `rake spec:parallel_deps` under ruby 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,11 @@ script:
   - BUNDLER_SPEC_PRE_RECORDED=1 bin/rake spec:realworld
 
 before_script:
-  - travis_retry bin/rake override_version
-  - travis_retry bin/rake spec:parallel_deps
+  - bin/rake override_version
+  - bin/rake spec:parallel_deps
   - if [ "$BUNDLER_SPEC_SUB_VERSION" = "" ];
     then
-      travis_retry sudo apt-get install graphviz -y;
+      sudo apt-get install graphviz -y;
     fi
   - if [ "$TRAVIS_RUBY_VERSION" = "2.3.8" ];
     then

--- a/spec/support/rubygems_ext.rb
+++ b/spec/support/rubygems_ext.rb
@@ -105,10 +105,14 @@ module Spec
     end
 
     def install_gems(gems)
-      deps = gems.map {|name, req| "'#{name}:#{req}'" }.join(" ")
-      gem = ENV["GEM_COMMAND"] || "#{Gem.ruby} -S gem --backtrace"
-      cmd = "#{gem} install #{deps} --no-document --conservative"
-      system(cmd) || raise("Installing gems #{deps} for the tests to use failed!")
+      require "rubygems/dependency_installer"
+
+      gems.each do |name, req|
+        dependency = Gem::Dependency.new(name, req)
+        next unless dependency.matching_specs.empty?
+
+        Gem::DependencyInstaller.new(:document => false).install(dependency)
+      end
     end
   end
 end


### PR DESCRIPTION
### What was the end-user or developer problem that led to this PR?

The problem is that `rake spec:parallel_deps` does not work under ruby 2.3. The only reason it's working on TravisCI is because the TravisCI configuration include `travis_retry` on `rake spec:parallel_deps` _does_ work on the second try.

I'm not sure why this is happening, but I would say it's a `Kernel.system` issue fixed on newer rubies. The reason for this is that this issue seems rubygems version independent. 

### What is your fix for the problem, implemented in this PR?

My fix is to install development dependencies programatically without shelling out. It should be faster, and it avoids the issue.

I'm also removing some unneeded `travis_retry` from the TravisCI configure. These steps shouldn't timeout and if they do, we should figure out why. Also, they could be hiding other issues not related to the network, like this one.

This fixes https://github.com/rubygems/bundler/pull/7660#discussion_r385603908.